### PR TITLE
feat: add user validation schema

### DIFF
--- a/lib/api/user_management/user.ex
+++ b/lib/api/user_management/user.ex
@@ -1,0 +1,30 @@
+defmodule Api.UserManagement.User do
+  use Api.Schema
+
+  import Ecto.Changeset
+
+  alias Argon2
+
+  schema "users" do
+    field :email, :string
+    field :name, :string
+    field :password, :string, redact: true
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs || %{}, [:email, :name, :password])
+    |> validate_required([:email, :name, :password])
+    |> unique_constraint(:id, name: :users_pkey)
+    |> unique_constraint(:email)
+    |> validate_length(:email, min: 3, max: 128)
+    |> update_change(:email, &String.downcase/1)
+    |> validate_format(:email, ~r/@/)
+    |> validate_length(:name, min: 2, max: 128)
+    |> validate_length(:password, min: 6, max: 128)
+    |> update_change(:password, &Argon2.hash_pwd_salt/1)
+  end
+end

--- a/test/api/user_management/user_test.exs
+++ b/test/api/user_management/user_test.exs
@@ -1,0 +1,171 @@
+defmodule Api.UserManagement.UserTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.UserManagement.User
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:user)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "changeset/1 returns a valid changeset" do
+    test "when email is valid", %{attrs: attrs} do
+      attrs = Map.put(attrs, :email, String.upcase(attrs.email))
+
+      changeset = User.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.email == String.downcase(attrs.email)
+    end
+
+    test "when name is valid", %{attrs: attrs} do
+      changeset = User.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.name == attrs.name
+    end
+
+    test "when password is valid", %{attrs: attrs} do
+      changeset = User.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert String.starts_with?(changeset.changes.password, "$argon2")
+    end
+  end
+
+  describe "changeset/1 returns an invalid changeset" do
+    test "when email is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :email, nil)
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.email == ["can't be blank"]
+    end
+
+    test "when email is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :email)
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.email == ["can't be blank"]
+    end
+
+    test "when email is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :email, "")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.email == ["can't be blank"]
+    end
+
+    test "when email has invalid format", %{attrs: attrs} do
+      attrs = Map.put(attrs, :email, "email.invalid")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.email == ["has invalid format"]
+    end
+
+    test "when email is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :email, "@")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.email == ["should be at least 3 character(s)"]
+    end
+
+    test "when name is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "?")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["should be at least 2 character(s)"]
+    end
+
+    test "when name is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, nil)
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :name)
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when password is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :password, "?")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.password == ["should be at least 6 character(s)"]
+    end
+
+    test "when password is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :password, nil)
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.password == ["can't be blank"]
+    end
+
+    test "when password is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :password)
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.password == ["can't be blank"]
+    end
+
+    test "when password is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :password, "")
+
+      changeset = User.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.password == ["can't be blank"]
+    end
+  end
+end

--- a/test/support/factories/user_factory.ex
+++ b/test/support/factories/user_factory.ex
@@ -1,0 +1,21 @@
+defmodule Api.Factories.UserFactory do
+  @moduledoc """
+  Generates user data for testing
+  """
+  alias Api.UserManagement.User
+
+  defmacro __using__(_opts) do
+    quote do
+      def user_factory do
+        %User{
+          id: Faker.UUID.v4(),
+          name: Faker.Person.name(),
+          email: Faker.Internet.email(),
+          password: Base.encode64(:crypto.strong_rand_bytes(32), padding: false),
+          inserted_at: Faker.DateTime.backward(366),
+          updated_at: DateTime.utc_now()
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,4 +3,6 @@ defmodule Api.Factory do
   Defines factory for generating data
   """
   use ExMachina.Ecto, repo: Api.Repo
+
+  use Api.Factories.UserFactory
 end


### PR DESCRIPTION
# description

add schema to validate users

## acceptance criteria
* must have at least 3 characters and max 128 for any attributes
* must check if `email` is valid
* must hash the `password` after validating it

# linked issues
- closes #9