### PR TITLE
feat: add routes to handle users

### DIFF
--- a/lib/api_web/controllers/fallback_controller.ex
+++ b/lib/api_web/controllers/fallback_controller.ex
@@ -1,0 +1,18 @@
+defmodule ApiWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use ApiWeb, :controller
+
+  @doc """
+  Handles errors returned by Ecto's insert/update/delete.
+  """
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ApiWeb.ChangesetView)
+    |> render("error.json", changeset: changeset)
+  end
+end

--- a/lib/api_web/controllers/user_controller.ex
+++ b/lib/api_web/controllers/user_controller.ex
@@ -1,0 +1,61 @@
+defmodule ApiWeb.UserController do
+  @moduledoc """
+  Controller responsible for handling users
+  """
+  use ApiWeb, :controller
+
+  alias Api.UserManagement
+  alias Api.UserManagement.User
+
+  action_fallback ApiWeb.FallbackController
+
+  @doc """
+  Handles requests to list users
+  """
+  def index(conn, _params) do
+    users = UserManagement.list_users()
+
+    render(conn, "index.json", users: users)
+  end
+
+  @doc """
+  Handles requests to create user
+  """
+  def create(conn, %{"user" => user_params}) do
+    with {:ok, %User{} = user} <- UserManagement.create_user(user_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.user_path(conn, :show, user))
+      |> render("show.json", user: user)
+    end
+  end
+
+  @doc """
+  Handles requests to show user
+  """
+  def show(conn, %{"id" => id}) do
+    with {:ok, user} <- UserManagement.get_user(id) do
+      render(conn, "show.json", user: user)
+    end
+  end
+
+  @doc """
+  Handles requests to update user
+  """
+  def update(conn, %{"id" => id, "user" => user_params}) do
+    with {:ok, user} <- UserManagement.get_user(id),
+         {:ok, %User{} = user} <- UserManagement.update_user(user, user_params) do
+      render(conn, "show.json", user: user)
+    end
+  end
+
+  @doc """
+  Handles requests to delete user
+  """
+  def delete(conn, %{"id" => id}) do
+    with {:ok, user} <- UserManagement.get_user(id),
+         {:ok, %User{}} <- UserManagement.delete_user(user) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -7,6 +7,8 @@ defmodule ApiWeb.Router do
 
   scope "/api", ApiWeb do
     pipe_through :api
+
+    resources "/users", UserController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/api_web/views/changeset_view.ex
+++ b/lib/api_web/views/changeset_view.ex
@@ -1,0 +1,23 @@
+defmodule ApiWeb.ChangesetView do
+  @moduledoc """
+  View responsible for rendering changeset errors
+  """
+  use ApiWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `ApiWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  @doc """
+  Renders changeset errors
+  """
+  def render("error.json", %{changeset: changeset}) do
+    %{success: false, errors: translate_errors(changeset)}
+  end
+end

--- a/lib/api_web/views/error_view.ex
+++ b/lib/api_web/views/error_view.ex
@@ -11,6 +11,9 @@ defmodule ApiWeb.ErrorView do
   # the template name. For example, "404.json" becomes
   # "Not Found".
   def template_not_found(template, _assigns) do
-    %{errors: %{detail: Phoenix.Controller.status_message_from_template(template)}}
+    %{
+      success: false,
+      errors: %{detail: Phoenix.Controller.status_message_from_template(template)}
+    }
   end
 end

--- a/lib/api_web/views/user_view.ex
+++ b/lib/api_web/views/user_view.ex
@@ -1,0 +1,33 @@
+defmodule ApiWeb.UserView do
+  @moduledoc """
+  View responsible for rendering users
+  """
+  use ApiWeb, :view
+
+  alias ApiWeb.UserView
+
+  @doc """
+  Renders a list of users
+  """
+  def render("index.json", %{users: users}) do
+    %{success: true, data: render_many(users, UserView, "user.json")}
+  end
+
+  @doc """
+  Renders a single user
+  """
+  def render("show.json", %{user: user}) do
+    %{success: true, data: render_one(user, UserView, "user.json")}
+  end
+
+  @doc """
+  Renders an user data
+  """
+  def render("user.json", %{user: user}) do
+    %{
+      id: user.id,
+      email: user.email,
+      name: user.name
+    }
+  end
+end

--- a/test/api_web/controllers/user_controller_test.exs
+++ b/test/api_web/controllers/user_controller_test.exs
@@ -1,0 +1,144 @@
+defmodule ApiWeb.UserControllerTest do
+  use ApiWeb.ConnCase
+
+  import Api.Factory
+
+  @id_not_found Ecto.UUID.generate()
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index/2 returns success" do
+    test "with an empty list when there are no users", %{conn: conn} do
+      conn = get(conn, Routes.user_path(conn, :index))
+
+      assert %{"success" => true, "data" => []} = json_response(conn, 200)
+    end
+
+    test "with a list of users when there are users", %{conn: conn} do
+      %{id: id, email: email, name: name} = insert(:user)
+
+      conn = get(conn, Routes.user_path(conn, :index))
+
+      assert %{"success" => true, "data" => [user]} = json_response(conn, 200)
+
+      assert user["id"] == id
+      assert user["email"] == email
+      assert user["name"] == name
+    end
+  end
+
+  describe "create/2 returns success" do
+    test "when the user parameters are valid", %{conn: conn} do
+      user_params = params_for(:user)
+
+      conn = post(conn, Routes.user_path(conn, :create), user: user_params)
+
+      assert %{"success" => true, "data" => user_data} = json_response(conn, 201)
+
+      assert user_data["email"] == user_params.email
+      assert user_data["name"] == user_params.name
+    end
+  end
+
+  describe "create/2 returns error" do
+    test "when the user parameters are invalid", %{conn: conn} do
+      user_params = %{email: "?", name: nil, password: "?"}
+
+      conn = post(conn, Routes.user_path(conn, :create), user: user_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["email"] == ["has invalid format", "should be at least 3 character(s)"]
+      assert errors["name"] == ["can't be blank"]
+      assert errors["password"] == ["should be at least 6 character(s)"]
+    end
+  end
+
+  describe "show/2 returns success" do
+    setup [:insert_user]
+
+    test "when the user id is found", %{conn: conn, user: user} do
+      conn = get(conn, Routes.user_path(conn, :show, user))
+
+      assert %{"success" => true, "data" => user_data} = json_response(conn, 200)
+
+      assert user_data["id"] == user.id
+      assert user_data["email"] == user.email
+      assert user_data["name"] == user.name
+    end
+  end
+
+  describe "show/2 returns error" do
+    test "when the user id is not found", %{conn: conn} do
+      conn = get(conn, Routes.user_path(conn, :show, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "update/2 returns success" do
+    setup [:insert_user]
+
+    test "when the user parameters are valid", %{conn: conn, user: user} do
+      user_params = params_for(:user)
+
+      conn = put(conn, Routes.user_path(conn, :update, user), user: user_params)
+
+      assert %{"success" => true, "data" => user_data} = json_response(conn, 200)
+
+      assert user_data["id"] == user.id
+      assert user_data["email"] == user_params.email
+      assert user_data["name"] == user_params.name
+    end
+  end
+
+  describe "update/2 returns error" do
+    setup [:insert_user]
+
+    test "when the user parameters are invalid", %{conn: conn, user: user} do
+      user_params = %{email: "@", name: "?", password: nil}
+
+      conn = put(conn, Routes.user_path(conn, :update, user), user: user_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["email"] == ["should be at least 3 character(s)"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+      assert errors["password"] == ["can't be blank"]
+    end
+  end
+
+  describe "delete/2 returns success" do
+    setup [:insert_user]
+
+    test "when the user is found", %{conn: conn, user: user} do
+      conn = delete(conn, Routes.user_path(conn, :delete, user))
+      assert response(conn, 204)
+
+      conn = get(conn, Routes.user_path(conn, :show, user))
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns error" do
+    test "when the user is not found", %{conn: conn} do
+      conn = delete(conn, Routes.user_path(conn, :delete, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  defp insert_user(_) do
+    :user
+    |> insert()
+    |> then(&{:ok, user: &1})
+  end
+end

--- a/test/api_web/views/changeset_view_test.exs
+++ b/test/api_web/views/changeset_view_test.exs
@@ -1,0 +1,19 @@
+defmodule ApiWeb.ChangesetViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+
+  alias Api.UserManagement.User
+  alias ApiWeb.ChangesetView
+
+  describe "render/3 returns error" do
+    test "with an user changeset" do
+      changeset = User.invalid_changeset(:id, Ecto.UUID.generate(), "not found")
+
+      assert json = render(ChangesetView, "error.json", changeset: changeset)
+
+      refute json.success
+      assert json.errors.id == ["not found"]
+    end
+  end
+end

--- a/test/api_web/views/error_view_test.exs
+++ b/test/api_web/views/error_view_test.exs
@@ -6,6 +6,8 @@ defmodule ApiWeb.ErrorViewTest do
   alias ApiWeb.ErrorView
 
   test "renders 500.json" do
-    assert render(ErrorView, "500.json", []) == %{errors: %{detail: "Internal Server Error"}}
+    assert %{success: false, errors: errors} = render(ErrorView, "500.json", [])
+
+    assert errors.detail == "Internal Server Error"
   end
 end

--- a/test/api_web/views/user_view_test.exs
+++ b/test/api_web/views/user_view_test.exs
@@ -1,0 +1,42 @@
+defmodule ApiWeb.UserViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Api.Factory
+
+  alias ApiWeb.UserView
+
+  describe "render/3 returns success" do
+    setup [:build_user]
+
+    test "with a list of users", %{user: user} do
+      assert %{success: true, data: [user_data]} = render(UserView, "index.json", users: [user])
+
+      assert user_data.id == user.id
+      assert user_data.email == user.email
+      assert user_data.name == user.name
+    end
+
+    test "with a single user", %{user: user} do
+      assert %{success: true, data: user_data} = render(UserView, "show.json", user: user)
+
+      assert user_data.id == user.id
+      assert user_data.email == user.email
+      assert user_data.name == user.name
+    end
+
+    test "with user data", %{user: user} do
+      assert user_data = render(UserView, "user.json", user: user)
+
+      assert user_data.id == user.id
+      assert user_data.email == user.email
+      assert user_data.name == user.name
+    end
+  end
+
+  defp build_user(_) do
+    :user
+    |> build()
+    |> then(&{:ok, user: &1})
+  end
+end


### PR DESCRIPTION
# description

add routes to handle users

## acceptance criteria
* must follow the `restful api` pattern
* should use prefix `/api/users` to the endpoints

## linked issues
- closes #11 