### PR TITLE
feat: add persons resource

### DIFF
--- a/lib/api/registry.ex
+++ b/lib/api/registry.ex
@@ -1,0 +1,89 @@
+defmodule Api.Registry do
+  @moduledoc """
+  The Registry context
+  """
+  alias Api.Registry.Change
+  alias Api.Registry.Create
+  alias Api.Registry.Delete
+  alias Api.Registry.Get
+  alias Api.Registry.List
+  alias Api.Registry.Update
+
+  @doc """
+  Returns a list of persons
+
+  ## Examples
+
+      iex> list_persons()
+      [%User{}, ...]
+
+  """
+  defdelegate list_persons, to: List, as: :call
+
+  @doc """
+  Gets a person
+
+  ## Examples
+
+      iex> get_person(value)
+      {:ok, %User{}}
+
+      iex> get_person(bad_value)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate get_person(id), to: Get, as: :call
+
+  @doc """
+  Creates a person
+
+  ## Examples
+
+      iex> create_person(%{field: value})
+      {:ok, %User{}}
+
+      iex> create_person(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate create_person(attrs \\ %{}), to: Create, as: :call
+
+  @doc """
+  Updates a person
+
+  ## Examples
+
+      iex> update_person(person, %{field: new_value})
+      {:ok, %User{}}
+
+      iex> update_person(person, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate update_person(person, attrs), to: Update, as: :call
+
+  @doc """
+  Deletes a person
+
+  ## Examples
+
+      iex> delete_person(person)
+      {:ok, %User{}}
+
+      iex> delete_person(person)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate delete_person(person), to: Delete, as: :call
+
+  @doc """
+  Returns a changeset for tracking person changes
+
+  ## Examples
+
+      iex> change_person(person)
+      %Ecto.Changeset{data: %User{}}
+
+  """
+  defdelegate change_person(person, attrs \\ %{}), to: Change, as: :call
+end

--- a/lib/api/registry/change.ex
+++ b/lib/api/registry/change.ex
@@ -1,0 +1,7 @@
+defmodule Api.Registry.Change do
+  @moduledoc false
+  alias Api.Registry.Person
+
+  @doc false
+  def call(%Person{} = person, attrs \\ %{}), do: Person.changeset(person, attrs)
+end

--- a/lib/api/registry/create.ex
+++ b/lib/api/registry/create.ex
@@ -1,0 +1,12 @@
+defmodule Api.Registry.Create do
+  @moduledoc false
+  alias Api.Registry.Person
+  alias Api.Repo
+
+  @doc false
+  def call(attrs \\ %{}) do
+    %Person{}
+    |> Person.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/api/registry/delete.ex
+++ b/lib/api/registry/delete.ex
@@ -1,0 +1,8 @@
+defmodule Api.Registry.Delete do
+  @moduledoc false
+  alias Api.Registry.Person
+  alias Api.Repo
+
+  @doc false
+  def call(%Person{} = person), do: Repo.delete(person)
+end

--- a/lib/api/registry/get.ex
+++ b/lib/api/registry/get.ex
@@ -1,0 +1,17 @@
+defmodule Api.Registry.Get do
+  @moduledoc false
+  alias Api.Registry.Person
+  alias Api.Repo
+
+  @doc false
+  def call(id) do
+    Person
+    |> Repo.get!(id)
+    |> then(&{:ok, &1})
+  rescue
+    _ ->
+      :id
+      |> Person.invalid_changeset(id, "not found")
+      |> then(&{:error, &1})
+  end
+end

--- a/lib/api/registry/list.ex
+++ b/lib/api/registry/list.ex
@@ -1,0 +1,8 @@
+defmodule Api.Registry.List do
+  @moduledoc false
+  alias Api.Registry.Person
+  alias Api.Repo
+
+  @doc false
+  def call, do: Repo.all(Person)
+end

--- a/lib/api/registry/person.ex
+++ b/lib/api/registry/person.ex
@@ -1,0 +1,27 @@
+defmodule Api.Registry.Person do
+  use Api.Schema
+
+  import Ecto.Changeset
+
+  schema "persons" do
+    field :alias, :string
+    field :name, :string
+    field :social_id, :string
+    field :type, Ecto.Enum, values: [natural: 0, juridical: 1, other: 2]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(person, attrs) do
+    person
+    |> cast(attrs, [:name, :alias, :social_id, :type])
+    |> validate_required([:name, :type])
+    |> unique_constraint(:id, name: :persons_pkey)
+    |> unique_constraint(:social_id)
+    |> validate_length(:alias, max: 150)
+    |> validate_length(:name, min: 2, max: 150)
+    |> validate_length(:social_id, max: 15)
+    |> validate_format(:social_id, ~r/^[0-9]+$/, message: "must contain only numbers")
+  end
+end

--- a/lib/api/registry/update.ex
+++ b/lib/api/registry/update.ex
@@ -1,0 +1,12 @@
+defmodule Api.Registry.Update do
+  @moduledoc false
+  alias Api.Registry.Person
+  alias Api.Repo
+
+  @doc false
+  def call(%Person{} = person, attrs) do
+    person
+    |> Person.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/lib/api_web/controllers/person_controller.ex
+++ b/lib/api_web/controllers/person_controller.ex
@@ -1,0 +1,61 @@
+defmodule ApiWeb.PersonController do
+  @moduledoc """
+  Controller responsible for handling persons
+  """
+  use ApiWeb, :controller
+
+  alias Api.Registry
+  alias Api.Registry.Person
+
+  action_fallback ApiWeb.FallbackController
+
+  @doc """
+  Handles requests to list persons
+  """
+  def index(conn, _params) do
+    persons = Registry.list_persons()
+
+    render(conn, "index.json", persons: persons)
+  end
+
+  @doc """
+  Handles requests to create person
+  """
+  def create(conn, %{"person" => person_params}) do
+    with {:ok, %Person{} = person} <- Registry.create_person(person_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.person_path(conn, :show, person))
+      |> render("show.json", person: person)
+    end
+  end
+
+  @doc """
+  Handles requests to show person
+  """
+  def show(conn, %{"id" => id}) do
+    with {:ok, person} <- Registry.get_person(id) do
+      render(conn, "show.json", person: person)
+    end
+  end
+
+  @doc """
+  Handles requests to update person
+  """
+  def update(conn, %{"id" => id, "person" => person_params}) do
+    with {:ok, person} <- Registry.get_person(id),
+         {:ok, %Person{} = person} <- Registry.update_person(person, person_params) do
+      render(conn, "show.json", person: person)
+    end
+  end
+
+  @doc """
+  Handles requests to delete person
+  """
+  def delete(conn, %{"id" => id}) do
+    with {:ok, person} <- Registry.get_person(id),
+         {:ok, %Person{}} <- Registry.delete_person(person) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -20,6 +20,7 @@ defmodule ApiWeb.Router do
     pipe_through [:api, :auth]
 
     resources "/users", UserController, except: [:new, :edit]
+    resources "/persons", PersonController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/api_web/views/person_view.ex
+++ b/lib/api_web/views/person_view.ex
@@ -1,0 +1,36 @@
+defmodule ApiWeb.PersonView do
+  @moduledoc """
+  View responsible for rendering persons
+  """
+  use ApiWeb, :view
+
+  alias Api.Registry.Person
+  alias ApiWeb.PersonView
+
+  @doc """
+  Renders a list of persons
+  """
+  def render("index.json", %{persons: persons}) do
+    %{success: true, data: render_many(persons, PersonView, "person.json")}
+  end
+
+  @doc """
+  Renders a single person
+  """
+  def render("show.json", %{person: person}) do
+    %{success: true, data: render_one(person, PersonView, "person.json")}
+  end
+
+  @doc """
+  Renders a person data
+  """
+  def render("person.json", %{person: person}) do
+    %{
+      id: person.id,
+      type: Ecto.Enum.mappings(Person, :type)[person.type],
+      name: person.name,
+      alias: person.alias,
+      social_id: person.social_id
+    }
+  end
+end

--- a/priv/repo/migrations/20230312192930_create_persons.exs
+++ b/priv/repo/migrations/20230312192930_create_persons.exs
@@ -1,0 +1,16 @@
+defmodule Api.Repo.Migrations.CreatePersons do
+  use Ecto.Migration
+
+  def change do
+    create table(:persons) do
+      add :alias, :string, size: 150
+      add :name, :string, size: 150, null: false
+      add :social_id, :string, size: 15
+      add :type, :integer, null: false, default: 1
+
+      timestamps()
+    end
+
+    create unique_index(:persons, [:social_id])
+  end
+end

--- a/test/api/registry/person_test.exs
+++ b/test/api/registry/person_test.exs
@@ -1,0 +1,129 @@
+defmodule Api.Registry.PersonTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Registry.Person
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:person)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "changeset/1 returns a valid changeset" do
+    test "when alias is valid", %{attrs: attrs} do
+      changeset = Person.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.alias == attrs.alias
+    end
+
+    test "when name is valid", %{attrs: attrs} do
+      changeset = Person.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.name == attrs.name
+    end
+
+    test "when social_id is valid", %{attrs: attrs} do
+      changeset = Person.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.social_id == attrs.social_id
+    end
+
+    test "when type is valid", %{attrs: attrs} do
+      changeset = Person.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.type == Enum.at(Ecto.Enum.values(Person, :type), attrs.type)
+    end
+  end
+
+  describe "changeset/1 returns an invalid changeset" do
+    test "when name is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, nil)
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :name)
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "")
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "?")
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["should be at least 2 character(s)"]
+    end
+
+    test "when social_id has invalid format", %{attrs: attrs} do
+      attrs = Map.put(attrs, :social_id, "invalid_format")
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.social_id == ["must contain only numbers"]
+    end
+
+    test "when social_id is too long", %{attrs: attrs} do
+      attrs = Map.put(attrs, :social_id, "01234567890123456789")
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.social_id == ["should be at most 15 character(s)"]
+    end
+
+    test "when type has invalid value", %{attrs: attrs} do
+      attrs = Map.put(attrs, :type, "6")
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.type == ["is invalid"]
+    end
+
+    test "when type is invalid", %{attrs: attrs} do
+      attrs = Map.put(attrs, :type, "invalid")
+
+      changeset = Person.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.type == ["is invalid"]
+    end
+  end
+end

--- a/test/api/registry_test.exs
+++ b/test/api/registry_test.exs
@@ -1,0 +1,150 @@
+defmodule Api.RegistryTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Registry
+  alias Api.Registry.Person
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:person)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "list_persons/0" do
+    test "without persons returns an empty list" do
+      assert [] == Registry.list_persons()
+    end
+
+    test "with persons returns all persons" do
+      person = insert(:person)
+
+      assert [person] == Registry.list_persons()
+    end
+  end
+
+  describe "get_person/1 returns :ok" do
+    setup [:insert_person]
+
+    test "when the given id is found", %{person: %{id: id} = person} do
+      assert {:ok, %Person{} = ^person} = Registry.get_person(id)
+    end
+  end
+
+  describe "get_person/1 returns :error" do
+    test "when the given id is not found" do
+      id = Ecto.UUID.generate()
+
+      assert {:error, changeset} = Registry.get_person(id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "create_person/1 returns :ok" do
+    test "when the person attributes are valid", %{attrs: attrs} do
+      assert {:ok, %Person{} = person} = Registry.create_person(attrs)
+
+      assert attrs.name == person.name
+      assert attrs.alias == person.alias
+      assert attrs.social_id == person.social_id
+      assert Enum.at(Ecto.Enum.values(Person, :type), attrs.type) == person.type
+    end
+  end
+
+  describe "create_person/1 returns :error" do
+    test "when the person attributes are invalid" do
+      attrs = %{alias: "?", name: nil, social_id: "?", type: 6}
+
+      assert {:error, changeset} = Registry.create_person(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["can't be blank"]
+      assert errors.social_id == ["must contain only numbers"]
+      assert errors.type == ["is invalid"]
+    end
+
+    test "when the person attributes is not provided" do
+      assert {:error, changeset} = Registry.create_person()
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["can't be blank"]
+      assert errors.type == ["can't be blank"]
+    end
+
+    test "when the person social_id already exists", %{attrs: attrs} do
+      attrs =
+        insert(:person)
+        |> then(&Map.put(attrs, :social_id, &1.social_id))
+
+      assert {:error, changeset} = Registry.create_person(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["has already been taken"] == errors.social_id
+    end
+  end
+
+  describe "update_person/2 returns :ok" do
+    setup [:insert_person]
+
+    test "when the person attributes are valid", %{person: person, attrs: attrs} do
+      assert {:ok, %Person{} = person} = Registry.update_person(person, attrs)
+
+      assert attrs.name == person.name
+      assert attrs.alias == person.alias
+      assert attrs.social_id == person.social_id
+      assert Enum.at(Ecto.Enum.values(Person, :type), attrs.type) == person.type
+    end
+  end
+
+  describe "update_person/2 returns :error" do
+    setup [:insert_person]
+
+    test "when the person attributes are invalid", %{person: person} do
+      invalid_attrs = %{alias: "@", social_id: "?", name: "a", type: nil}
+
+      assert {:error, changeset} = Registry.update_person(person, invalid_attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["should be at least 2 character(s)"] == errors.name
+      assert ["can't be blank"] == errors.type
+      assert {:ok, person} == Registry.get_person(person.id)
+    end
+  end
+
+  describe "delete_person/1" do
+    setup [:insert_person]
+
+    test "deletes the person", %{person: person} do
+      assert {:ok, %Person{}} = Registry.delete_person(person)
+
+      assert {:error, changeset} = Registry.get_person(person.id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "change_person/1" do
+    setup [:insert_person]
+
+    test "returns a changeset", %{person: person} do
+      assert %Changeset{} = Registry.change_person(person)
+    end
+  end
+
+  defp insert_person(_) do
+    :person
+    |> insert()
+    |> then(&{:ok, person: &1})
+  end
+end

--- a/test/api_web/controllers/person_controller_test.exs
+++ b/test/api_web/controllers/person_controller_test.exs
@@ -1,0 +1,163 @@
+defmodule ApiWeb.PersonControllerTest do
+  use ApiWeb.ConnCase
+
+  import Api.Factory
+
+  alias Api.Registry.Person
+
+  @id_not_found Ecto.UUID.generate()
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index/2 returns success" do
+    setup [:insert_person, :put_auth]
+
+    test "with a list of persons when there are persons", %{conn: conn, person: person} do
+      conn = get(conn, Routes.person_path(conn, :index))
+
+      assert %{"success" => true, "data" => [person_data]} = json_response(conn, 200)
+
+      assert person_data["id"] == person.id
+      assert person_data["alias"] == person.alias
+      assert person_data["name"] == person.name
+      assert person_data["social_id"] == person.social_id
+      assert person_data["type"] == Ecto.Enum.mappings(Person, :type)[person.type]
+    end
+  end
+
+  describe "create/2 returns success" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person parameters are valid", %{conn: conn} do
+      person_params = params_for(:person)
+
+      conn = post(conn, Routes.person_path(conn, :create), person: person_params)
+
+      assert %{"success" => true, "data" => person_data} = json_response(conn, 201)
+
+      assert person_data["name"] == person_params.name
+      assert person_data["alias"] == person_params.alias
+      assert person_data["social_id"] == person_params.social_id
+      assert person_data["type"] == person_params.type
+    end
+  end
+
+  describe "create/2 returns error" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person parameters are invalid", %{conn: conn} do
+      person_params = %{alias: "?", name: "?", social_id: "?", type: nil}
+
+      conn = post(conn, Routes.person_path(conn, :create), person: person_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["type"] == ["can't be blank"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+  end
+
+  describe "show/2 returns success" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person id is found", %{conn: conn, person: person} do
+      conn = get(conn, Routes.person_path(conn, :show, person))
+
+      assert %{"success" => true, "data" => person_data} = json_response(conn, 200)
+
+      assert person_data["id"] == person.id
+      assert person_data["alias"] == person.alias
+      assert person_data["name"] == person.name
+      assert person_data["social_id"] == person.social_id
+      assert person_data["type"] == Ecto.Enum.mappings(Person, :type)[person.type]
+    end
+  end
+
+  describe "show/2 returns error" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person id is not found", %{conn: conn} do
+      conn = get(conn, Routes.person_path(conn, :show, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "update/2 returns success" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person parameters are valid", %{conn: conn, person: person} do
+      person_params = params_for(:person)
+
+      conn = put(conn, Routes.person_path(conn, :update, person), person: person_params)
+
+      assert %{"success" => true, "data" => person_data} = json_response(conn, 200)
+
+      assert person_data["id"] == person.id
+      assert person_data["alias"] == person_params.alias
+      assert person_data["name"] == person_params.name
+      assert person_data["social_id"] == person_params.social_id
+      assert person_data["type"] == person_params.type
+    end
+  end
+
+  describe "update/2 returns error" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person parameters are invalid", %{conn: conn, person: person} do
+      person_params = %{alias: "@", name: nil, social_id: "invalid", type: 6}
+
+      conn = put(conn, Routes.person_path(conn, :update, person), person: person_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["name"] == ["can't be blank"]
+      assert errors["social_id"] == ["must contain only numbers"]
+      assert errors["type"] == ["is invalid"]
+    end
+  end
+
+  describe "delete/2 returns success" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person is found", %{conn: conn, person: person} do
+      conn = delete(conn, Routes.person_path(conn, :delete, person))
+      assert response(conn, 204)
+
+      conn = get(conn, Routes.person_path(conn, :show, person))
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns error" do
+    setup [:insert_person, :put_auth]
+
+    test "when the person is not found", %{conn: conn} do
+      conn = delete(conn, Routes.person_path(conn, :delete, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  defp insert_person(_) do
+    :person
+    |> insert()
+    |> then(&{:ok, person: &1})
+  end
+
+  defp put_auth(%{conn: conn}) do
+    %{token: %{access: token}} = build(:auth)
+
+    conn
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> then(&{:ok, conn: &1})
+  end
+end

--- a/test/api_web/views/person_view_test.exs
+++ b/test/api_web/views/person_view_test.exs
@@ -1,0 +1,51 @@
+defmodule ApiWeb.PersonViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Api.Factory
+
+  alias Api.Registry.Person
+  alias ApiWeb.PersonView
+
+  describe "render/3 returns success" do
+    setup [:build_person]
+
+    test "with a list of persons", %{person: person} do
+      assert %{success: true, data: data} = render(PersonView, "index.json", persons: [person])
+      assert [person_data] = data
+
+      assert person_data.id == person.id
+      assert person_data.type == Ecto.Enum.mappings(Person, :type)[person.type]
+      assert person_data.alias == person.alias
+      assert person_data.name == person.name
+      assert person_data.social_id == person.social_id
+    end
+
+    test "with a single person", %{person: person} do
+      assert %{success: true, data: person_data} = render(PersonView, "show.json", person: person)
+
+      assert person_data.id == person.id
+      assert person_data.type == Ecto.Enum.mappings(Person, :type)[person.type]
+      assert person_data.alias == person.alias
+      assert person_data.name == person.name
+      assert person_data.social_id == person.social_id
+    end
+
+    test "with person data", %{person: person} do
+      assert person_data = render(PersonView, "person.json", person: person)
+
+      assert person_data.id == person.id
+      assert person_data.type == Ecto.Enum.mappings(Person, :type)[person.type]
+      assert person_data.alias == person.alias
+      assert person_data.name == person.name
+      assert person_data.social_id == person.social_id
+    end
+  end
+
+  defp build_person(_) do
+    :person
+    |> build()
+    |> then(&Map.put(&1, :type, Enum.at(Ecto.Enum.values(Person, :type), &1.type)))
+    |> then(&{:ok, person: &1})
+  end
+end

--- a/test/support/factories/person_factory.ex
+++ b/test/support/factories/person_factory.ex
@@ -1,0 +1,22 @@
+defmodule Api.Factories.PersonFactory do
+  @moduledoc """
+  Generates person data for testing
+  """
+  alias Api.Registry.Person
+
+  defmacro __using__(_opts) do
+    quote do
+      def person_factory do
+        %Person{
+          id: Faker.UUID.v4(),
+          name: Faker.Person.name(),
+          alias: Faker.Person.name(),
+          type: Faker.Random.Elixir.random_between(0, 2),
+          social_id: "#{Faker.Random.Elixir.random_between(11_111_111_111, 99_999_999_999_999)}",
+          inserted_at: Faker.DateTime.backward(366),
+          updated_at: DateTime.utc_now()
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/person_factory.ex
+++ b/test/support/factories/person_factory.ex
@@ -2,6 +2,7 @@ defmodule Api.Factories.PersonFactory do
   @moduledoc """
   Generates person data for testing
   """
+  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
   alias Api.Registry.Person
 
   defmacro __using__(_opts) do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -6,4 +6,5 @@ defmodule Api.Factory do
 
   use Api.Factories.UserFactory
   use Api.Factories.AuthFactory
+  use Api.Factories.PersonFactory
 end


### PR DESCRIPTION
# description

add routes to handle persons natural and juridical

## acceptance criteria
* must follow the `restful api` pattern
* should use prefix `/api/persons` to the endpoints

## linked issues
- closes #27 
- closes #28 
- closes #29 
- closes #30 