### PR TITLE
feat: add countries resource

### DIFF
--- a/lib/api/location.ex
+++ b/lib/api/location.ex
@@ -1,0 +1,89 @@
+defmodule Api.Location do
+  @moduledoc """
+  The Location context
+  """
+  alias Api.Location.Change
+  alias Api.Location.Create
+  alias Api.Location.Delete
+  alias Api.Location.Get
+  alias Api.Location.List
+  alias Api.Location.Update
+
+  @doc """
+  Returns a list of countries
+
+  ## Examples
+
+      iex> list_countries()
+      [%Country{}, ...]
+
+  """
+  defdelegate list_countries, to: List, as: :call
+
+  @doc """
+  Gets a country
+
+  ## Examples
+
+      iex> get_country(value)
+      {:ok, %Country{}}
+
+      iex> get_country(bad_value)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate get_country(id), to: Get, as: :call
+
+  @doc """
+  Creates a country
+
+  ## Examples
+
+      iex> create_country(%{field: value})
+      {:ok, %Country{}}
+
+      iex> create_country(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate create_country(attrs \\ %{}), to: Create, as: :call
+
+  @doc """
+  Updates a country
+
+  ## Examples
+
+      iex> update_country(country, %{field: new_value})
+      {:ok, %Country{}}
+
+      iex> update_country(country, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate update_country(country, attrs), to: Update, as: :call
+
+  @doc """
+  Deletes a country
+
+  ## Examples
+
+      iex> delete_country(country)
+      {:ok, %Country{}}
+
+      iex> delete_country(country)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate delete_country(country), to: Delete, as: :call
+
+  @doc """
+  Returns a changeset for tracking country changes
+
+  ## Examples
+
+      iex> change_country(country)
+      %Ecto.Changeset{data: %Country{}}
+
+  """
+  defdelegate change_country(country, attrs \\ %{}), to: Change, as: :call
+end

--- a/lib/api/location/change.ex
+++ b/lib/api/location/change.ex
@@ -1,0 +1,7 @@
+defmodule Api.Location.Change do
+  @moduledoc false
+  alias Api.Location.Country
+
+  @doc false
+  def call(%Country{} = country, attrs \\ %{}), do: Country.changeset(country, attrs)
+end

--- a/lib/api/location/country.ex
+++ b/lib/api/location/country.ex
@@ -1,0 +1,25 @@
+defmodule Api.Location.Country do
+  use Api.Schema
+
+  import Ecto.Changeset
+
+  schema "countries" do
+    field :code, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(country, attrs) do
+    country
+    |> cast(attrs, [:code, :name])
+    |> validate_required([:code, :name])
+    |> unique_constraint(:code)
+    |> unique_constraint(:id, name: :countries_pkey)
+    |> validate_length(:code, is: 2)
+    |> update_change(:code, &String.upcase/1)
+    |> validate_format(:code, ~r/^[A-Z]+$/, message: "must contain only characters A-Z")
+    |> validate_length(:name, min: 2, max: 150)
+  end
+end

--- a/lib/api/location/create.ex
+++ b/lib/api/location/create.ex
@@ -1,0 +1,12 @@
+defmodule Api.Location.Create do
+  @moduledoc false
+  alias Api.Location.Country
+  alias Api.Repo
+
+  @doc false
+  def call(attrs \\ %{}) do
+    %Country{}
+    |> Country.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/api/location/delete.ex
+++ b/lib/api/location/delete.ex
@@ -1,0 +1,8 @@
+defmodule Api.Location.Delete do
+  @moduledoc false
+  alias Api.Location.Country
+  alias Api.Repo
+
+  @doc false
+  def call(%Country{} = country), do: Repo.delete(country)
+end

--- a/lib/api/location/get.ex
+++ b/lib/api/location/get.ex
@@ -1,0 +1,17 @@
+defmodule Api.Location.Get do
+  @moduledoc false
+  alias Api.Location.Country
+  alias Api.Repo
+
+  @doc false
+  def call(id) do
+    Country
+    |> Repo.get!(id)
+    |> then(&{:ok, &1})
+  rescue
+    _ ->
+      :id
+      |> Country.invalid_changeset(id, "not found")
+      |> then(&{:error, &1})
+  end
+end

--- a/lib/api/location/list.ex
+++ b/lib/api/location/list.ex
@@ -1,0 +1,8 @@
+defmodule Api.Location.List do
+  @moduledoc false
+  alias Api.Location.Country
+  alias Api.Repo
+
+  @doc false
+  def call, do: Repo.all(Country)
+end

--- a/lib/api/location/update.ex
+++ b/lib/api/location/update.ex
@@ -1,0 +1,12 @@
+defmodule Api.Location.Update do
+  @moduledoc false
+  alias Api.Location.Country
+  alias Api.Repo
+
+  @doc false
+  def call(%Country{} = country, attrs) do
+    country
+    |> Country.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/lib/api/registry.ex
+++ b/lib/api/registry.ex
@@ -15,7 +15,7 @@ defmodule Api.Registry do
   ## Examples
 
       iex> list_persons()
-      [%User{}, ...]
+      [%Person{}, ...]
 
   """
   defdelegate list_persons, to: List, as: :call
@@ -26,7 +26,7 @@ defmodule Api.Registry do
   ## Examples
 
       iex> get_person(value)
-      {:ok, %User{}}
+      {:ok, %Person{}}
 
       iex> get_person(bad_value)
       {:error, %Ecto.Changeset{}}
@@ -40,7 +40,7 @@ defmodule Api.Registry do
   ## Examples
 
       iex> create_person(%{field: value})
-      {:ok, %User{}}
+      {:ok, %Person{}}
 
       iex> create_person(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
@@ -54,7 +54,7 @@ defmodule Api.Registry do
   ## Examples
 
       iex> update_person(person, %{field: new_value})
-      {:ok, %User{}}
+      {:ok, %Person{}}
 
       iex> update_person(person, %{field: bad_value})
       {:error, %Ecto.Changeset{}}
@@ -68,7 +68,7 @@ defmodule Api.Registry do
   ## Examples
 
       iex> delete_person(person)
-      {:ok, %User{}}
+      {:ok, %Person{}}
 
       iex> delete_person(person)
       {:error, %Ecto.Changeset{}}
@@ -82,7 +82,7 @@ defmodule Api.Registry do
   ## Examples
 
       iex> change_person(person)
-      %Ecto.Changeset{data: %User{}}
+      %Ecto.Changeset{data: %Person{}}
 
   """
   defdelegate change_person(person, attrs \\ %{}), to: Change, as: :call

--- a/lib/api_web/controllers/country_controller.ex
+++ b/lib/api_web/controllers/country_controller.ex
@@ -1,0 +1,61 @@
+defmodule ApiWeb.CountryController do
+  @moduledoc """
+  Controller responsible for handling countries
+  """
+  use ApiWeb, :controller
+
+  alias Api.Location
+  alias Api.Location.Country
+
+  action_fallback ApiWeb.FallbackController
+
+  @doc """
+  Handles requests to list countries
+  """
+  def index(conn, _params) do
+    countries = Location.list_countries()
+
+    render(conn, "index.json", countries: countries)
+  end
+
+  @doc """
+  Handles requests to create country
+  """
+  def create(conn, %{"country" => country_params}) do
+    with {:ok, %Country{} = country} <- Location.create_country(country_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.country_path(conn, :show, country))
+      |> render("show.json", country: country)
+    end
+  end
+
+  @doc """
+  Handles requests to show country
+  """
+  def show(conn, %{"id" => id}) do
+    with {:ok, country} <- Location.get_country(id) do
+      render(conn, "show.json", country: country)
+    end
+  end
+
+  @doc """
+  Handles requests to update country
+  """
+  def update(conn, %{"id" => id, "country" => country_params}) do
+    with {:ok, country} <- Location.get_country(id),
+         {:ok, %Country{} = country} <- Location.update_country(country, country_params) do
+      render(conn, "show.json", country: country)
+    end
+  end
+
+  @doc """
+  Handles requests to delete country
+  """
+  def delete(conn, %{"id" => id}) do
+    with {:ok, country} <- Location.get_country(id),
+         {:ok, %Country{}} <- Location.delete_country(country) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -21,6 +21,7 @@ defmodule ApiWeb.Router do
 
     resources "/users", UserController, except: [:new, :edit]
     resources "/persons", PersonController, except: [:new, :edit]
+    resources "/countries", CountryController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/api_web/views/country_view.ex
+++ b/lib/api_web/views/country_view.ex
@@ -1,0 +1,33 @@
+defmodule ApiWeb.CountryView do
+  @moduledoc """
+  View responsible for rendering countries
+  """
+  use ApiWeb, :view
+
+  alias ApiWeb.CountryView
+
+  @doc """
+  Renders a list of countries
+  """
+  def render("index.json", %{countries: countries}) do
+    %{success: true, data: render_many(countries, CountryView, "country.json")}
+  end
+
+  @doc """
+  Renders a single country
+  """
+  def render("show.json", %{country: country}) do
+    %{success: true, data: render_one(country, CountryView, "country.json")}
+  end
+
+  @doc """
+  Renders a country data
+  """
+  def render("country.json", %{country: country}) do
+    %{
+      id: country.id,
+      name: country.name,
+      code: country.code
+    }
+  end
+end

--- a/priv/repo/migrations/20230314003548_create_countries.exs
+++ b/priv/repo/migrations/20230314003548_create_countries.exs
@@ -1,0 +1,14 @@
+defmodule Api.Repo.Migrations.CreateCountries do
+  use Ecto.Migration
+
+  def change do
+    create table(:countries) do
+      add :code, :string, size: 5, null: false
+      add :name, :string, size: 150, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:countries, [:code])
+  end
+end

--- a/test/api/location/country_test.exs
+++ b/test/api/location/country_test.exs
@@ -1,0 +1,122 @@
+defmodule Api.Location.CountryTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Location.Country
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:country) |> IO.inspect(label: :debug)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "changeset/1 returns a valid changeset" do
+    test "when name is valid", %{attrs: attrs} do
+      changeset = Country.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.name == attrs.name
+    end
+
+    test "when code is valid", %{attrs: attrs} do
+      changeset = Country.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.code == attrs.code
+    end
+  end
+
+  describe "changeset/1 returns an invalid changeset" do
+    test "when name is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, nil)
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :name)
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "")
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "?")
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["should be at least 2 character(s)"]
+    end
+
+    test "when code is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, nil)
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :code)
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "")
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "A")
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["should be 2 character(s)"]
+    end
+
+    test "when code is invalid", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "??")
+
+      changeset = Country.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["must contain only characters A-Z"]
+    end
+  end
+end

--- a/test/api/location/country_test.exs
+++ b/test/api/location/country_test.exs
@@ -7,7 +7,7 @@ defmodule Api.Location.CountryTest do
   alias Ecto.Changeset
 
   setup do
-    attrs = params_for(:country) |> IO.inspect(label: :debug)
+    attrs = params_for(:country)
 
     {:ok, attrs: attrs}
   end

--- a/test/api/location_test.exs
+++ b/test/api/location_test.exs
@@ -1,0 +1,145 @@
+defmodule Api.LocationTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Location
+  alias Api.Location.Country
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:country)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "list_countries/0" do
+    test "without countries returns an empty list" do
+      assert [] == Location.list_countries()
+    end
+
+    test "with countries returns all countries" do
+      country = insert(:country)
+
+      assert [country] == Location.list_countries()
+    end
+  end
+
+  describe "get_country/1 returns :ok" do
+    setup [:insert_country]
+
+    test "when the given id is found", %{country: %{id: id} = country} do
+      assert {:ok, %Country{} = ^country} = Location.get_country(id)
+    end
+  end
+
+  describe "get_country/1 returns :error" do
+    test "when the given id is not found" do
+      id = Ecto.UUID.generate()
+
+      assert {:error, changeset} = Location.get_country(id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "create_country/1 returns :ok" do
+    test "when the country attributes are valid", %{attrs: attrs} do
+      assert {:ok, %Country{} = country} = Location.create_country(attrs)
+
+      assert attrs.name == country.name
+      assert attrs.code == country.code
+    end
+  end
+
+  describe "create_country/1 returns :error" do
+    test "when the country attributes are invalid" do
+      attrs = %{code: "??", name: "?"}
+
+      assert {:error, changeset} = Location.create_country(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["should be at least 2 character(s)"]
+      assert errors.code == ["must contain only characters A-Z"]
+    end
+
+    test "when the country attributes is not provided" do
+      assert {:error, changeset} = Location.create_country()
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["can't be blank"]
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when the country code already exists", %{attrs: attrs} do
+      attrs =
+        insert(:country)
+        |> then(&Map.put(attrs, :code, &1.code))
+
+      assert {:error, changeset} = Location.create_country(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["has already been taken"] == errors.code
+    end
+  end
+
+  describe "update_country/2 returns :ok" do
+    setup [:insert_country]
+
+    test "when the country attributes are valid", %{country: country, attrs: attrs} do
+      assert {:ok, %Country{} = country} = Location.update_country(country, attrs)
+
+      assert attrs.name == country.name
+      assert attrs.code == country.code
+    end
+  end
+
+  describe "update_country/2 returns :error" do
+    setup [:insert_country]
+
+    test "when the country attributes are invalid", %{country: country} do
+      invalid_attrs = %{code: nil, name: "a"}
+
+      assert {:error, changeset} = Location.update_country(country, invalid_attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["should be at least 2 character(s)"] == errors.name
+      assert ["can't be blank"] == errors.code
+      assert {:ok, country} == Location.get_country(country.id)
+    end
+  end
+
+  describe "delete_country/1" do
+    setup [:insert_country]
+
+    test "deletes the country", %{country: country} do
+      assert {:ok, %Country{}} = Location.delete_country(country)
+
+      assert {:error, changeset} = Location.get_country(country.id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "change_country/1" do
+    setup [:insert_country]
+
+    test "returns a changeset", %{country: country} do
+      assert %Changeset{} = Location.change_country(country)
+    end
+  end
+
+  defp insert_country(_) do
+    :country
+    |> insert()
+    |> then(&{:ok, country: &1})
+  end
+end

--- a/test/api_web/controllers/country_controller_test.exs
+++ b/test/api_web/controllers/country_controller_test.exs
@@ -1,0 +1,152 @@
+defmodule ApiWeb.CountryControllerTest do
+  use ApiWeb.ConnCase
+
+  import Api.Factory
+
+  @id_not_found Ecto.UUID.generate()
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index/2 returns success" do
+    setup [:insert_country, :put_auth]
+
+    test "with a list of countries when there are countries", %{conn: conn, country: country} do
+      conn = get(conn, Routes.country_path(conn, :index))
+
+      assert %{"success" => true, "data" => [country_data]} = json_response(conn, 200)
+
+      assert country_data["id"] == country.id
+      assert country_data["name"] == country.name
+      assert country_data["code"] == country.code
+    end
+  end
+
+  describe "create/2 returns success" do
+    setup [:put_auth]
+
+    test "when the country parameters are valid", %{conn: conn} do
+      country_params = params_for(:country)
+
+      conn = post(conn, Routes.country_path(conn, :create), country: country_params)
+
+      assert %{"success" => true, "data" => country_data} = json_response(conn, 201)
+
+      assert country_data["name"] == country_params.name
+      assert country_data["code"] == country_params.code
+    end
+  end
+
+  describe "create/2 returns error" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country parameters are invalid", %{conn: conn} do
+      country_params = %{name: "?", code: "??"}
+
+      conn = post(conn, Routes.country_path(conn, :create), country: country_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["code"] == ["must contain only characters A-Z"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+  end
+
+  describe "show/2 returns success" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country id is found", %{conn: conn, country: country} do
+      conn = get(conn, Routes.country_path(conn, :show, country))
+
+      assert %{"success" => true, "data" => country_data} = json_response(conn, 200)
+
+      assert country_data["id"] == country.id
+      assert country_data["name"] == country.name
+      assert country_data["code"] == country.code
+    end
+  end
+
+  describe "show/2 returns error" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country id is not found", %{conn: conn} do
+      conn = get(conn, Routes.country_path(conn, :show, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "update/2 returns success" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country parameters are valid", %{conn: conn, country: country} do
+      country_params = params_for(:country)
+
+      conn = put(conn, Routes.country_path(conn, :update, country), country: country_params)
+
+      assert %{"success" => true, "data" => country_data} = json_response(conn, 200)
+
+      assert country_data["id"] == country.id
+      assert country_data["name"] == country_params.name
+      assert country_data["code"] == country_params.code
+    end
+  end
+
+  describe "update/2 returns error" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country parameters are invalid", %{conn: conn, country: country} do
+      country_params = %{name: "?", code: nil}
+
+      conn = put(conn, Routes.country_path(conn, :update, country), country: country_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["code"] == ["can't be blank"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+  end
+
+  describe "delete/2 returns success" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country is found", %{conn: conn, country: country} do
+      conn = delete(conn, Routes.country_path(conn, :delete, country))
+      assert response(conn, 204)
+
+      conn = get(conn, Routes.country_path(conn, :show, country))
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns error" do
+    setup [:insert_country, :put_auth]
+
+    test "when the country is not found", %{conn: conn} do
+      conn = delete(conn, Routes.country_path(conn, :delete, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  defp insert_country(_) do
+    :country
+    |> insert()
+    |> then(&{:ok, country: &1})
+  end
+
+  defp put_auth(%{conn: conn}) do
+    %{token: %{access: token}} = build(:auth)
+
+    conn
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> then(&{:ok, conn: &1})
+  end
+end

--- a/test/api_web/views/country_view_test.exs
+++ b/test/api_web/views/country_view_test.exs
@@ -1,0 +1,46 @@
+defmodule ApiWeb.CountryViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Api.Factory
+
+  alias ApiWeb.CountryView
+
+  describe "render/3 returns success" do
+    setup [:build_country]
+
+    test "with a list of countries", %{country: country} do
+      assert %{success: true, data: data} =
+               render(CountryView, "index.json", countries: [country])
+
+      assert [country_data] = data
+
+      assert country_data.id == country.id
+      assert country_data.code == country.code
+      assert country_data.name == country.name
+    end
+
+    test "with a single country", %{country: country} do
+      assert %{success: true, data: country_data} =
+               render(CountryView, "show.json", country: country)
+
+      assert country_data.id == country.id
+      assert country_data.code == country.code
+      assert country_data.name == country.name
+    end
+
+    test "with country data", %{country: country} do
+      assert country_data = render(CountryView, "country.json", country: country)
+
+      assert country_data.id == country.id
+      assert country_data.code == country.code
+      assert country_data.name == country.name
+    end
+  end
+
+  defp build_country(_) do
+    :country
+    |> build()
+    |> then(&{:ok, country: &1})
+  end
+end

--- a/test/support/factories/country_factory.ex
+++ b/test/support/factories/country_factory.ex
@@ -1,0 +1,21 @@
+defmodule Api.Factories.CountryFactory do
+  @moduledoc """
+  Generates country data for testing
+  """
+  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
+  alias Api.Location.Country
+
+  defmacro __using__(_opts) do
+    quote do
+      def country_factory do
+        %Country{
+          id: Faker.UUID.v4(),
+          name: Faker.Address.PtBr.country(),
+          code: Faker.Address.country_code(),
+          inserted_at: Faker.DateTime.backward(366),
+          updated_at: DateTime.utc_now()
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -7,4 +7,5 @@ defmodule Api.Factory do
   use Api.Factories.UserFactory
   use Api.Factories.AuthFactory
   use Api.Factories.PersonFactory
+  use Api.Factories.CountryFactory
 end


### PR DESCRIPTION
# description

add routes to handle countries

## acceptance criteria
* must follow the `restful api` pattern
* should use prefix `/api/countries` to the endpoints

## linked issues
- closes #31 
- closes #32 
- closes #33 
- closes #34 