### PR TITLE
feat: add states resource

### DIFF
--- a/lib/api/location.ex
+++ b/lib/api/location.ex
@@ -96,6 +96,17 @@ defmodule Api.Location do
   defdelegate list_states, to: State.List, as: :call
 
   @doc """
+  Returns a list of states filtered by country id
+
+  ## Examples
+
+      iex> list_states(country_id: country_id)
+      [%State{}, ...]
+
+  """
+  defdelegate list_states(filter), to: State.List, as: :call
+
+  @doc """
   Gets a state
 
   ## Examples
@@ -172,6 +183,17 @@ defmodule Api.Location do
 
   """
   defdelegate list_cities, to: City.List, as: :call
+
+  @doc """
+  Returns a list of cities filtered by state id
+
+  ## Examples
+
+      iex> list_cities(state_id: state_id)
+      [%State{}, ...]
+
+  """
+  defdelegate list_cities(filter), to: City.List, as: :call
 
   @doc """
   Gets a city

--- a/lib/api/location.ex
+++ b/lib/api/location.ex
@@ -2,12 +2,7 @@ defmodule Api.Location do
   @moduledoc """
   The Location context
   """
-  alias Api.Location.Change
-  alias Api.Location.Create
-  alias Api.Location.Delete
-  alias Api.Location.Get
-  alias Api.Location.List
-  alias Api.Location.Update
+  alias Api.Location.Country
 
   @doc """
   Returns a list of countries
@@ -18,7 +13,7 @@ defmodule Api.Location do
       [%Country{}, ...]
 
   """
-  defdelegate list_countries, to: List, as: :call
+  defdelegate list_countries, to: Country.List, as: :call
 
   @doc """
   Gets a country
@@ -32,7 +27,7 @@ defmodule Api.Location do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate get_country(id), to: Get, as: :call
+  defdelegate get_country(id), to: Country.Get, as: :call
 
   @doc """
   Creates a country
@@ -46,7 +41,7 @@ defmodule Api.Location do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate create_country(attrs \\ %{}), to: Create, as: :call
+  defdelegate create_country(attrs \\ %{}), to: Country.Create, as: :call
 
   @doc """
   Updates a country
@@ -60,7 +55,7 @@ defmodule Api.Location do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate update_country(country, attrs), to: Update, as: :call
+  defdelegate update_country(country, attrs), to: Country.Update, as: :call
 
   @doc """
   Deletes a country
@@ -74,7 +69,7 @@ defmodule Api.Location do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate delete_country(country), to: Delete, as: :call
+  defdelegate delete_country(country), to: Country.Delete, as: :call
 
   @doc """
   Returns a changeset for tracking country changes
@@ -85,5 +80,5 @@ defmodule Api.Location do
       %Ecto.Changeset{data: %Country{}}
 
   """
-  defdelegate change_country(country, attrs \\ %{}), to: Change, as: :call
+  defdelegate change_country(country, attrs \\ %{}), to: Country.Change, as: :call
 end

--- a/lib/api/location.ex
+++ b/lib/api/location.ex
@@ -2,6 +2,7 @@ defmodule Api.Location do
   @moduledoc """
   The Location context
   """
+  alias Api.Location.City
   alias Api.Location.Country
   alias Api.Location.State
 
@@ -160,4 +161,82 @@ defmodule Api.Location do
 
   """
   defdelegate change_state(state, attrs \\ %{}), to: State.Change, as: :call
+
+  @doc """
+  Returns a list of cities
+
+  ## Examples
+
+      iex> list_cities()
+      [%City{}, ...]
+
+  """
+  defdelegate list_cities, to: City.List, as: :call
+
+  @doc """
+  Gets a city
+
+  ## Examples
+
+      iex> get_city(value)
+      {:ok, %City{}}
+
+      iex> get_city(bad_value)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate get_city(id), to: City.Get, as: :call
+
+  @doc """
+  Creates a city
+
+  ## Examples
+
+      iex> create_city(%{field: value})
+      {:ok, %City{}}
+
+      iex> create_city(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate create_city(attrs \\ %{}), to: City.Create, as: :call
+
+  @doc """
+  Updates a city
+
+  ## Examples
+
+      iex> update_city(city, %{field: new_value})
+      {:ok, %City{}}
+
+      iex> update_city(city, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate update_city(city, attrs), to: City.Update, as: :call
+
+  @doc """
+  Deletes a city
+
+  ## Examples
+
+      iex> delete_city(city)
+      {:ok, %City{}}
+
+      iex> delete_city(city)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate delete_city(city), to: City.Delete, as: :call
+
+  @doc """
+  Returns a changeset for tracking city changes
+
+  ## Examples
+
+      iex> change_city(city)
+      %Ecto.Changeset{data: %City{}}
+
+  """
+  defdelegate change_city(city, attrs \\ %{}), to: City.Change, as: :call
 end

--- a/lib/api/location.ex
+++ b/lib/api/location.ex
@@ -3,6 +3,7 @@ defmodule Api.Location do
   The Location context
   """
   alias Api.Location.Country
+  alias Api.Location.State
 
   @doc """
   Returns a list of countries
@@ -81,4 +82,82 @@ defmodule Api.Location do
 
   """
   defdelegate change_country(country, attrs \\ %{}), to: Country.Change, as: :call
+
+  @doc """
+  Returns a list of states
+
+  ## Examples
+
+      iex> list_states()
+      [%State{}, ...]
+
+  """
+  defdelegate list_states, to: State.List, as: :call
+
+  @doc """
+  Gets a state
+
+  ## Examples
+
+      iex> get_state(value)
+      {:ok, %State{}}
+
+      iex> get_state(bad_value)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate get_state(id), to: State.Get, as: :call
+
+  @doc """
+  Creates a state
+
+  ## Examples
+
+      iex> create_state(%{field: value})
+      {:ok, %State{}}
+
+      iex> create_state(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate create_state(attrs \\ %{}), to: State.Create, as: :call
+
+  @doc """
+  Updates a state
+
+  ## Examples
+
+      iex> update_state(state, %{field: new_value})
+      {:ok, %State{}}
+
+      iex> update_state(state, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate update_state(state, attrs), to: State.Update, as: :call
+
+  @doc """
+  Deletes a state
+
+  ## Examples
+
+      iex> delete_state(state)
+      {:ok, %State{}}
+
+      iex> delete_state(state)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate delete_state(state), to: State.Delete, as: :call
+
+  @doc """
+  Returns a changeset for tracking state changes
+
+  ## Examples
+
+      iex> change_state(state)
+      %Ecto.Changeset{data: %State{}}
+
+  """
+  defdelegate change_state(state, attrs \\ %{}), to: State.Change, as: :call
 end

--- a/lib/api/location/city.ex
+++ b/lib/api/location/city.ex
@@ -1,0 +1,24 @@
+defmodule Api.Location.City do
+  use Api.Schema
+
+  import Ecto.Changeset
+
+  alias Api.Location.State
+
+  schema "cities" do
+    field :name, :string
+    belongs_to :state, State
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(city, attrs) do
+    city
+    |> cast(attrs, [:name, :state_id])
+    |> validate_required([:name])
+    |> unique_constraint(:id, name: :cities_pkey)
+    |> assoc_constraint(:state)
+    |> validate_length(:name, min: 2, max: 150)
+  end
+end

--- a/lib/api/location/city/change.ex
+++ b/lib/api/location/city/change.ex
@@ -1,0 +1,7 @@
+defmodule Api.Location.City.Change do
+  @moduledoc false
+  alias Api.Location.City
+
+  @doc false
+  def call(%City{} = city, attrs \\ %{}), do: City.changeset(city, attrs)
+end

--- a/lib/api/location/city/create.ex
+++ b/lib/api/location/city/create.ex
@@ -1,0 +1,12 @@
+defmodule Api.Location.City.Create do
+  @moduledoc false
+  alias Api.Location.City
+  alias Api.Repo
+
+  @doc false
+  def call(attrs \\ %{}) do
+    %City{}
+    |> City.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/api/location/city/delete.ex
+++ b/lib/api/location/city/delete.ex
@@ -1,0 +1,8 @@
+defmodule Api.Location.City.Delete do
+  @moduledoc false
+  alias Api.Location.City
+  alias Api.Repo
+
+  @doc false
+  def call(%City{} = city), do: Repo.delete(city)
+end

--- a/lib/api/location/city/get.ex
+++ b/lib/api/location/city/get.ex
@@ -1,0 +1,17 @@
+defmodule Api.Location.City.Get do
+  @moduledoc false
+  alias Api.Location.City
+  alias Api.Repo
+
+  @doc false
+  def call(id) do
+    City
+    |> Repo.get!(id)
+    |> then(&{:ok, &1})
+  rescue
+    _ ->
+      :id
+      |> City.invalid_changeset(id, "not found")
+      |> then(&{:error, &1})
+  end
+end

--- a/lib/api/location/city/list.ex
+++ b/lib/api/location/city/list.ex
@@ -1,0 +1,8 @@
+defmodule Api.Location.City.List do
+  @moduledoc false
+  alias Api.Location.City
+  alias Api.Repo
+
+  @doc false
+  def call, do: Repo.all(City)
+end

--- a/lib/api/location/city/list.ex
+++ b/lib/api/location/city/list.ex
@@ -1,8 +1,18 @@
 defmodule Api.Location.City.List do
   @moduledoc false
+  import Ecto.Query, only: [from: 2]
+
   alias Api.Location.City
   alias Api.Repo
 
   @doc false
   def call, do: Repo.all(City)
+
+  def call(state_id: state_id) do
+    query =
+      from c in City,
+        where: c.state_id == ^state_id
+
+    Repo.all(query)
+  end
 end

--- a/lib/api/location/city/update.ex
+++ b/lib/api/location/city/update.ex
@@ -1,0 +1,12 @@
+defmodule Api.Location.City.Update do
+  @moduledoc false
+  alias Api.Location.City
+  alias Api.Repo
+
+  @doc false
+  def call(%City{} = city, attrs) do
+    city
+    |> City.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/lib/api/location/country.ex
+++ b/lib/api/location/country.ex
@@ -3,9 +3,12 @@ defmodule Api.Location.Country do
 
   import Ecto.Changeset
 
+  alias Api.Location.State
+
   schema "countries" do
     field :code, :string
     field :name, :string
+    has_many :states, State
 
     timestamps()
   end
@@ -17,6 +20,7 @@ defmodule Api.Location.Country do
     |> validate_required([:code, :name])
     |> unique_constraint(:code)
     |> unique_constraint(:id, name: :countries_pkey)
+    |> cast_assoc(:states)
     |> validate_length(:code, is: 2)
     |> update_change(:code, &String.upcase/1)
     |> validate_format(:code, ~r/^[A-Z]+$/, message: "must contain only characters A-Z")

--- a/lib/api/location/country/change.ex
+++ b/lib/api/location/country/change.ex
@@ -1,4 +1,4 @@
-defmodule Api.Location.Change do
+defmodule Api.Location.Country.Change do
   @moduledoc false
   alias Api.Location.Country
 

--- a/lib/api/location/country/create.ex
+++ b/lib/api/location/country/create.ex
@@ -1,12 +1,12 @@
-defmodule Api.Location.Update do
+defmodule Api.Location.Country.Create do
   @moduledoc false
   alias Api.Location.Country
   alias Api.Repo
 
   @doc false
-  def call(%Country{} = country, attrs) do
-    country
+  def call(attrs \\ %{}) do
+    %Country{}
     |> Country.changeset(attrs)
-    |> Repo.update()
+    |> Repo.insert()
   end
 end

--- a/lib/api/location/country/delete.ex
+++ b/lib/api/location/country/delete.ex
@@ -1,4 +1,4 @@
-defmodule Api.Location.Delete do
+defmodule Api.Location.Country.Delete do
   @moduledoc false
   alias Api.Location.Country
   alias Api.Repo

--- a/lib/api/location/country/get.ex
+++ b/lib/api/location/country/get.ex
@@ -1,17 +1,17 @@
-defmodule Api.Registry.Get do
+defmodule Api.Location.Country.Get do
   @moduledoc false
-  alias Api.Registry.Person
+  alias Api.Location.Country
   alias Api.Repo
 
   @doc false
   def call(id) do
-    Person
+    Country
     |> Repo.get!(id)
     |> then(&{:ok, &1})
   rescue
     _ ->
       :id
-      |> Person.invalid_changeset(id, "not found")
+      |> Country.invalid_changeset(id, "not found")
       |> then(&{:error, &1})
   end
 end

--- a/lib/api/location/country/list.ex
+++ b/lib/api/location/country/list.ex
@@ -1,4 +1,4 @@
-defmodule Api.Location.List do
+defmodule Api.Location.Country.List do
   @moduledoc false
   alias Api.Location.Country
   alias Api.Repo

--- a/lib/api/location/country/update.ex
+++ b/lib/api/location/country/update.ex
@@ -1,12 +1,12 @@
-defmodule Api.Location.Create do
+defmodule Api.Location.Country.Update do
   @moduledoc false
   alias Api.Location.Country
   alias Api.Repo
 
   @doc false
-  def call(attrs \\ %{}) do
-    %Country{}
+  def call(%Country{} = country, attrs) do
+    country
     |> Country.changeset(attrs)
-    |> Repo.insert()
+    |> Repo.update()
   end
 end

--- a/lib/api/location/state.ex
+++ b/lib/api/location/state.ex
@@ -3,9 +3,12 @@ defmodule Api.Location.State do
 
   import Ecto.Changeset
 
+  alias Api.Location.Country
+
   schema "states" do
     field :code, :string
     field :name, :string
+    belongs_to :country, Country
 
     timestamps()
   end
@@ -13,9 +16,10 @@ defmodule Api.Location.State do
   @doc false
   def changeset(state, attrs) do
     state
-    |> cast(attrs, [:name, :code])
+    |> cast(attrs, [:name, :code, :country_id])
     |> validate_required([:name, :code])
     |> unique_constraint(:id, name: :states_pkey)
+    |> assoc_constraint(:country)
     |> validate_length(:code, is: 2)
     |> update_change(:code, &String.upcase/1)
     |> validate_format(:code, ~r/^[A-Z]+$/, message: "must contain only characters A-Z")

--- a/lib/api/location/state.ex
+++ b/lib/api/location/state.ex
@@ -3,12 +3,14 @@ defmodule Api.Location.State do
 
   import Ecto.Changeset
 
+  alias Api.Location.City
   alias Api.Location.Country
 
   schema "states" do
     field :code, :string
     field :name, :string
     belongs_to :country, Country
+    has_many :cities, City
 
     timestamps()
   end
@@ -19,6 +21,7 @@ defmodule Api.Location.State do
     |> cast(attrs, [:name, :code, :country_id])
     |> validate_required([:name, :code])
     |> unique_constraint(:id, name: :states_pkey)
+    |> cast_assoc(:cities)
     |> assoc_constraint(:country)
     |> validate_length(:code, is: 2)
     |> update_change(:code, &String.upcase/1)

--- a/lib/api/location/state.ex
+++ b/lib/api/location/state.ex
@@ -1,0 +1,24 @@
+defmodule Api.Location.State do
+  use Api.Schema
+
+  import Ecto.Changeset
+
+  schema "states" do
+    field :code, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(state, attrs) do
+    state
+    |> cast(attrs, [:name, :code])
+    |> validate_required([:name, :code])
+    |> unique_constraint(:id, name: :states_pkey)
+    |> validate_length(:code, is: 2)
+    |> update_change(:code, &String.upcase/1)
+    |> validate_format(:code, ~r/^[A-Z]+$/, message: "must contain only characters A-Z")
+    |> validate_length(:name, min: 2, max: 150)
+  end
+end

--- a/lib/api/location/state/change.ex
+++ b/lib/api/location/state/change.ex
@@ -1,0 +1,7 @@
+defmodule Api.Location.State.Change do
+  @moduledoc false
+  alias Api.Location.State
+
+  @doc false
+  def call(%State{} = state, attrs \\ %{}), do: State.changeset(state, attrs)
+end

--- a/lib/api/location/state/create.ex
+++ b/lib/api/location/state/create.ex
@@ -1,0 +1,12 @@
+defmodule Api.Location.State.Create do
+  @moduledoc false
+  alias Api.Location.State
+  alias Api.Repo
+
+  @doc false
+  def call(attrs \\ %{}) do
+    %State{}
+    |> State.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/api/location/state/delete.ex
+++ b/lib/api/location/state/delete.ex
@@ -1,0 +1,8 @@
+defmodule Api.Location.State.Delete do
+  @moduledoc false
+  alias Api.Location.State
+  alias Api.Repo
+
+  @doc false
+  def call(%State{} = state), do: Repo.delete(state)
+end

--- a/lib/api/location/state/get.ex
+++ b/lib/api/location/state/get.ex
@@ -1,0 +1,17 @@
+defmodule Api.Location.State.Get do
+  @moduledoc false
+  alias Api.Location.State
+  alias Api.Repo
+
+  @doc false
+  def call(id) do
+    State
+    |> Repo.get!(id)
+    |> then(&{:ok, &1})
+  rescue
+    _ ->
+      :id
+      |> State.invalid_changeset(id, "not found")
+      |> then(&{:error, &1})
+  end
+end

--- a/lib/api/location/state/list.ex
+++ b/lib/api/location/state/list.ex
@@ -1,8 +1,18 @@
 defmodule Api.Location.State.List do
   @moduledoc false
+  import Ecto.Query, only: [from: 2]
+
   alias Api.Location.State
   alias Api.Repo
 
   @doc false
   def call, do: Repo.all(State)
+
+  def call(country_id: country_id) do
+    query =
+      from s in State,
+        where: s.country_id == ^country_id
+
+    Repo.all(query)
+  end
 end

--- a/lib/api/location/state/list.ex
+++ b/lib/api/location/state/list.ex
@@ -1,0 +1,8 @@
+defmodule Api.Location.State.List do
+  @moduledoc false
+  alias Api.Location.State
+  alias Api.Repo
+
+  @doc false
+  def call, do: Repo.all(State)
+end

--- a/lib/api/location/state/update.ex
+++ b/lib/api/location/state/update.ex
@@ -1,0 +1,12 @@
+defmodule Api.Location.State.Update do
+  @moduledoc false
+  alias Api.Location.State
+  alias Api.Repo
+
+  @doc false
+  def call(%State{} = state, attrs) do
+    state
+    |> State.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/lib/api/registry.ex
+++ b/lib/api/registry.ex
@@ -2,12 +2,7 @@ defmodule Api.Registry do
   @moduledoc """
   The Registry context
   """
-  alias Api.Registry.Change
-  alias Api.Registry.Create
-  alias Api.Registry.Delete
-  alias Api.Registry.Get
-  alias Api.Registry.List
-  alias Api.Registry.Update
+  alias Api.Registry.Person
 
   @doc """
   Returns a list of persons
@@ -18,7 +13,7 @@ defmodule Api.Registry do
       [%Person{}, ...]
 
   """
-  defdelegate list_persons, to: List, as: :call
+  defdelegate list_persons, to: Person.List, as: :call
 
   @doc """
   Gets a person
@@ -32,7 +27,7 @@ defmodule Api.Registry do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate get_person(id), to: Get, as: :call
+  defdelegate get_person(id), to: Person.Get, as: :call
 
   @doc """
   Creates a person
@@ -46,7 +41,7 @@ defmodule Api.Registry do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate create_person(attrs \\ %{}), to: Create, as: :call
+  defdelegate create_person(attrs \\ %{}), to: Person.Create, as: :call
 
   @doc """
   Updates a person
@@ -60,7 +55,7 @@ defmodule Api.Registry do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate update_person(person, attrs), to: Update, as: :call
+  defdelegate update_person(person, attrs), to: Person.Update, as: :call
 
   @doc """
   Deletes a person
@@ -74,7 +69,7 @@ defmodule Api.Registry do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate delete_person(person), to: Delete, as: :call
+  defdelegate delete_person(person), to: Person.Delete, as: :call
 
   @doc """
   Returns a changeset for tracking person changes
@@ -85,5 +80,5 @@ defmodule Api.Registry do
       %Ecto.Changeset{data: %Person{}}
 
   """
-  defdelegate change_person(person, attrs \\ %{}), to: Change, as: :call
+  defdelegate change_person(person, attrs \\ %{}), to: Person.Change, as: :call
 end

--- a/lib/api/registry/person/change.ex
+++ b/lib/api/registry/person/change.ex
@@ -1,4 +1,4 @@
-defmodule Api.Registry.Change do
+defmodule Api.Registry.Person.Change do
   @moduledoc false
   alias Api.Registry.Person
 

--- a/lib/api/registry/person/create.ex
+++ b/lib/api/registry/person/create.ex
@@ -1,4 +1,4 @@
-defmodule Api.Registry.Create do
+defmodule Api.Registry.Person.Create do
   @moduledoc false
   alias Api.Registry.Person
   alias Api.Repo

--- a/lib/api/registry/person/delete.ex
+++ b/lib/api/registry/person/delete.ex
@@ -1,4 +1,4 @@
-defmodule Api.Registry.Delete do
+defmodule Api.Registry.Person.Delete do
   @moduledoc false
   alias Api.Registry.Person
   alias Api.Repo

--- a/lib/api/registry/person/get.ex
+++ b/lib/api/registry/person/get.ex
@@ -1,17 +1,17 @@
-defmodule Api.Location.Get do
+defmodule Api.Registry.Person.Get do
   @moduledoc false
-  alias Api.Location.Country
+  alias Api.Registry.Person
   alias Api.Repo
 
   @doc false
   def call(id) do
-    Country
+    Person
     |> Repo.get!(id)
     |> then(&{:ok, &1})
   rescue
     _ ->
       :id
-      |> Country.invalid_changeset(id, "not found")
+      |> Person.invalid_changeset(id, "not found")
       |> then(&{:error, &1})
   end
 end

--- a/lib/api/registry/person/list.ex
+++ b/lib/api/registry/person/list.ex
@@ -1,4 +1,4 @@
-defmodule Api.Registry.List do
+defmodule Api.Registry.Person.List do
   @moduledoc false
   alias Api.Registry.Person
   alias Api.Repo

--- a/lib/api/registry/person/update.ex
+++ b/lib/api/registry/person/update.ex
@@ -1,4 +1,4 @@
-defmodule Api.Registry.Update do
+defmodule Api.Registry.Person.Update do
   @moduledoc false
   alias Api.Registry.Person
   alias Api.Repo

--- a/lib/api/user_management.ex
+++ b/lib/api/user_management.ex
@@ -2,12 +2,7 @@ defmodule Api.UserManagement do
   @moduledoc """
   The User Management context
   """
-  alias Api.UserManagement.Change
-  alias Api.UserManagement.Create
-  alias Api.UserManagement.Delete
-  alias Api.UserManagement.Get
-  alias Api.UserManagement.List
-  alias Api.UserManagement.Update
+  alias Api.UserManagement.User
 
   @doc """
   Returns a list of users
@@ -18,7 +13,7 @@ defmodule Api.UserManagement do
       [%User{}, ...]
 
   """
-  defdelegate list_users, to: List, as: :call
+  defdelegate list_users, to: User.List, as: :call
 
   @doc """
   Gets an user
@@ -32,7 +27,7 @@ defmodule Api.UserManagement do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate get_user(id), to: Get, as: :call
+  defdelegate get_user(id), to: User.Get, as: :call
 
   @doc """
   Creates an user
@@ -46,7 +41,7 @@ defmodule Api.UserManagement do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate create_user(attrs \\ %{}), to: Create, as: :call
+  defdelegate create_user(attrs \\ %{}), to: User.Create, as: :call
 
   @doc """
   Updates an user
@@ -60,7 +55,7 @@ defmodule Api.UserManagement do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate update_user(user, attrs), to: Update, as: :call
+  defdelegate update_user(user, attrs), to: User.Update, as: :call
 
   @doc """
   Deletes an user
@@ -74,7 +69,7 @@ defmodule Api.UserManagement do
       {:error, %Ecto.Changeset{}}
 
   """
-  defdelegate delete_user(user), to: Delete, as: :call
+  defdelegate delete_user(user), to: User.Delete, as: :call
 
   @doc """
   Returns a changeset for tracking user changes
@@ -85,5 +80,5 @@ defmodule Api.UserManagement do
       %Ecto.Changeset{data: %User{}}
 
   """
-  defdelegate change_user(user, attrs \\ %{}), to: Change, as: :call
+  defdelegate change_user(user, attrs \\ %{}), to: User.Change, as: :call
 end

--- a/lib/api/user_management/user/change.ex
+++ b/lib/api/user_management/user/change.ex
@@ -1,4 +1,4 @@
-defmodule Api.UserManagement.Change do
+defmodule Api.UserManagement.User.Change do
   @moduledoc false
   alias Api.UserManagement.User
 

--- a/lib/api/user_management/user/create.ex
+++ b/lib/api/user_management/user/create.ex
@@ -1,4 +1,4 @@
-defmodule Api.UserManagement.Create do
+defmodule Api.UserManagement.User.Create do
   @moduledoc false
   alias Api.Repo
   alias Api.UserManagement.User

--- a/lib/api/user_management/user/delete.ex
+++ b/lib/api/user_management/user/delete.ex
@@ -1,4 +1,4 @@
-defmodule Api.UserManagement.Delete do
+defmodule Api.UserManagement.User.Delete do
   @moduledoc false
   alias Api.Repo
   alias Api.UserManagement.User

--- a/lib/api/user_management/user/get.ex
+++ b/lib/api/user_management/user/get.ex
@@ -1,4 +1,4 @@
-defmodule Api.UserManagement.Get do
+defmodule Api.UserManagement.User.Get do
   @moduledoc false
   alias Api.Repo
   alias Api.UserManagement.User

--- a/lib/api/user_management/user/list.ex
+++ b/lib/api/user_management/user/list.ex
@@ -1,4 +1,4 @@
-defmodule Api.UserManagement.List do
+defmodule Api.UserManagement.User.List do
   @moduledoc false
   alias Api.Repo
   alias Api.UserManagement.User

--- a/lib/api/user_management/user/update.ex
+++ b/lib/api/user_management/user/update.ex
@@ -1,4 +1,4 @@
-defmodule Api.UserManagement.Update do
+defmodule Api.UserManagement.User.Update do
   @moduledoc false
   alias Api.Repo
   alias Api.UserManagement.User

--- a/lib/api_web/controllers/city_controller.ex
+++ b/lib/api_web/controllers/city_controller.ex
@@ -14,7 +14,7 @@ defmodule ApiWeb.CityController do
   def index(conn, %{"country_id" => country_id, "state_id" => state_id}) do
     with {:ok, _country} <- Location.get_country(country_id),
          {:ok, _state} <- Location.get_state(state_id),
-         cities <- Location.list_cities() do
+         cities <- Location.list_cities(state_id: state_id) do
       render(conn, "index.json", cities: cities)
     end
   end

--- a/lib/api_web/controllers/city_controller.ex
+++ b/lib/api_web/controllers/city_controller.ex
@@ -1,0 +1,80 @@
+defmodule ApiWeb.CityController do
+  @moduledoc """
+  Controller responsible for handling cities
+  """
+  use ApiWeb, :controller
+
+  alias Api.Location
+
+  action_fallback ApiWeb.FallbackController
+
+  @doc """
+  Handles requests to list cities
+  """
+  def index(conn, %{"country_id" => country_id, "state_id" => state_id}) do
+    with {:ok, _country} <- Location.get_country(country_id),
+         {:ok, _state} <- Location.get_state(state_id),
+         cities <- Location.list_cities() do
+      render(conn, "index.json", cities: cities)
+    end
+  end
+
+  @doc """
+  Handles requests to create city
+  """
+  def create(conn, %{"country_id" => country_id, "state_id" => state_id, "city" => city_params}) do
+    city_params = Map.put(city_params, "state_id", state_id)
+
+    with {:ok, _country} <- Location.get_country(country_id),
+         {:ok, _state} <- Location.get_state(state_id),
+         {:ok, city} <- Location.create_city(city_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header(
+        "location",
+        Routes.country_state_city_path(conn, :show, country_id, state_id, city)
+      )
+      |> render("show.json", city: city)
+    end
+  end
+
+  @doc """
+  Handles requests to show city
+  """
+  def show(conn, %{"country_id" => country_id, "state_id" => state_id, "id" => id}) do
+    with {:ok, _country} <- Location.get_country(country_id),
+         {:ok, _state} <- Location.get_state(state_id),
+         {:ok, city} <- Location.get_city(id) do
+      render(conn, "show.json", city: city)
+    end
+  end
+
+  @doc """
+  Handles requests to update city
+  """
+  def update(conn, %{
+        "country_id" => country_id,
+        "state_id" => state_id,
+        "id" => id,
+        "city" => city_params
+      }) do
+    with {:ok, _country} <- Location.get_country(country_id),
+         {:ok, _state} <- Location.get_state(state_id),
+         {:ok, city} <- Location.get_city(id),
+         {:ok, city} <- Location.update_city(city, city_params) do
+      render(conn, "show.json", city: city)
+    end
+  end
+
+  @doc """
+  Handles requests to delete city
+  """
+  def delete(conn, %{"country_id" => country_id, "state_id" => state_id, "id" => id}) do
+    with {:ok, _country} <- Location.get_country(country_id),
+         {:ok, _state} <- Location.get_state(state_id),
+         {:ok, city} <- Location.get_city(id),
+         {:ok, _city} <- Location.delete_city(city) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/api_web/controllers/state_controller.ex
+++ b/lib/api_web/controllers/state_controller.ex
@@ -13,7 +13,7 @@ defmodule ApiWeb.StateController do
   """
   def index(conn, %{"country_id" => country_id}) do
     with {:ok, _country} <- Location.get_country(country_id),
-         states <- Location.list_states() do
+         states <- Location.list_states(country_id: country_id) do
       render(conn, "index.json", states: states)
     end
   end

--- a/lib/api_web/controllers/state_controller.ex
+++ b/lib/api_web/controllers/state_controller.ex
@@ -1,0 +1,61 @@
+defmodule ApiWeb.StateController do
+  @moduledoc """
+  Controller responsible for handling states
+  """
+  use ApiWeb, :controller
+
+  alias Api.Location
+  alias Api.Location.State
+
+  action_fallback ApiWeb.FallbackController
+
+  @doc """
+  Handles requests to list states
+  """
+  def index(conn, _params) do
+    states = Location.list_states()
+
+    render(conn, "index.json", states: states)
+  end
+
+  @doc """
+  Handles requests to create state
+  """
+  def create(conn, %{"state" => state_params}) do
+    with {:ok, %State{} = state} <- Location.create_state(state_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.state_path(conn, :show, state))
+      |> render("show.json", state: state)
+    end
+  end
+
+  @doc """
+  Handles requests to show state
+  """
+  def show(conn, %{"id" => id}) do
+    with {:ok, state} <- Location.get_state(id) do
+      render(conn, "show.json", state: state)
+    end
+  end
+
+  @doc """
+  Handles requests to update state
+  """
+  def update(conn, %{"id" => id, "state" => state_params}) do
+    with {:ok, state} <- Location.get_state(id),
+         {:ok, %State{} = state} <- Location.update_state(state, state_params) do
+      render(conn, "show.json", state: state)
+    end
+  end
+
+  @doc """
+  Handles requests to delete state
+  """
+  def delete(conn, %{"id" => id}) do
+    with {:ok, state} <- Location.get_state(id),
+         {:ok, %State{}} <- Location.delete_state(state) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -21,8 +21,10 @@ defmodule ApiWeb.Router do
 
     resources "/users", UserController, except: [:new, :edit]
     resources "/persons", PersonController, except: [:new, :edit]
-    resources "/countries", CountryController, except: [:new, :edit]
-    resources "/states", StateController, except: [:new, :edit]
+
+    resources "/countries", CountryController, except: [:new, :edit] do
+      resources "/states", StateController, except: [:new, :edit]
+    end
   end
 
   # Enables LiveDashboard only for development

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -23,7 +23,9 @@ defmodule ApiWeb.Router do
     resources "/persons", PersonController, except: [:new, :edit]
 
     resources "/countries", CountryController, except: [:new, :edit] do
-      resources "/states", StateController, except: [:new, :edit]
+      resources "/states", StateController, except: [:new, :edit] do
+        resources "/cities", CityController, except: [:new, :edit]
+      end
     end
   end
 

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -22,6 +22,7 @@ defmodule ApiWeb.Router do
     resources "/users", UserController, except: [:new, :edit]
     resources "/persons", PersonController, except: [:new, :edit]
     resources "/countries", CountryController, except: [:new, :edit]
+    resources "/states", StateController, except: [:new, :edit]
   end
 
   # Enables LiveDashboard only for development

--- a/lib/api_web/views/city_view.ex
+++ b/lib/api_web/views/city_view.ex
@@ -1,0 +1,33 @@
+defmodule ApiWeb.CityView do
+  @moduledoc """
+  View responsible for rendering states
+  """
+  use ApiWeb, :view
+
+  alias ApiWeb.CityView
+
+  @doc """
+  Renders a list of cities
+  """
+  def render("index.json", %{cities: cities}) do
+    %{success: true, data: render_many(cities, CityView, "city.json")}
+  end
+
+  @doc """
+  Renders a single city
+  """
+  def render("show.json", %{city: city}) do
+    %{success: true, data: render_one(city, CityView, "city.json")}
+  end
+
+  @doc """
+  Renders a city data
+  """
+  def render("city.json", %{city: city}) do
+    %{
+      id: city.id,
+      name: city.name,
+      state_id: city.state_id
+    }
+  end
+end

--- a/lib/api_web/views/state_view.ex
+++ b/lib/api_web/views/state_view.ex
@@ -1,0 +1,33 @@
+defmodule ApiWeb.StateView do
+  @moduledoc """
+  View responsible for rendering states
+  """
+  use ApiWeb, :view
+
+  alias ApiWeb.StateView
+
+  @doc """
+  Renders a list of states
+  """
+  def render("index.json", %{states: states}) do
+    %{success: true, data: render_many(states, StateView, "state.json")}
+  end
+
+  @doc """
+  Renders a single state
+  """
+  def render("show.json", %{state: state}) do
+    %{success: true, data: render_one(state, StateView, "state.json")}
+  end
+
+  @doc """
+  Renders a state data
+  """
+  def render("state.json", %{state: state}) do
+    %{
+      id: state.id,
+      name: state.name,
+      code: state.code
+    }
+  end
+end

--- a/lib/api_web/views/state_view.ex
+++ b/lib/api_web/views/state_view.ex
@@ -27,7 +27,8 @@ defmodule ApiWeb.StateView do
     %{
       id: state.id,
       name: state.name,
-      code: state.code
+      code: state.code,
+      country_id: state.country_id
     }
   end
 end

--- a/priv/repo/migrations/20230314022027_create_states.exs
+++ b/priv/repo/migrations/20230314022027_create_states.exs
@@ -5,8 +5,11 @@ defmodule Api.Repo.Migrations.CreateStates do
     create table(:states) do
       add :code, :string, size: 5, null: false
       add :name, :string, size: 150, null: false
+      add :country_id, references(:countries, on_delete: :delete_all), null: false
 
       timestamps()
     end
+
+    create index(:states, [:country_id])
   end
 end

--- a/priv/repo/migrations/20230314022027_create_states.exs
+++ b/priv/repo/migrations/20230314022027_create_states.exs
@@ -1,0 +1,12 @@
+defmodule Api.Repo.Migrations.CreateStates do
+  use Ecto.Migration
+
+  def change do
+    create table(:states) do
+      add :code, :string, size: 5, null: false
+      add :name, :string, size: 150, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20230315021239_create_cities.exs
+++ b/priv/repo/migrations/20230315021239_create_cities.exs
@@ -1,0 +1,14 @@
+defmodule Api.Repo.Migrations.CreateCities do
+  use Ecto.Migration
+
+  def change do
+    create table(:cities) do
+      add :name, :string, size: 150, null: false
+      add :state_id, references(:states, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:cities, [:state_id])
+  end
+end

--- a/test/api/location/city_test.exs
+++ b/test/api/location/city_test.exs
@@ -1,0 +1,65 @@
+defmodule Api.Location.CityTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Location.City
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:city)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "changeset/1 returns a valid changeset" do
+    test "when name is valid", %{attrs: attrs} do
+      changeset = City.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.name == attrs.name
+    end
+  end
+
+  describe "changeset/1 returns an invalid changeset" do
+    test "when name is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, nil)
+
+      changeset = City.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :name)
+
+      changeset = City.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "")
+
+      changeset = City.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "?")
+
+      changeset = City.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["should be at least 2 character(s)"]
+    end
+  end
+end

--- a/test/api/location/state_test.exs
+++ b/test/api/location/state_test.exs
@@ -1,0 +1,122 @@
+defmodule Api.Location.StateTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Location.State
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:state)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "changeset/1 returns a valid changeset" do
+    test "when name is valid", %{attrs: attrs} do
+      changeset = State.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.name == attrs.name
+    end
+
+    test "when code is valid", %{attrs: attrs} do
+      changeset = State.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.code == attrs.code
+    end
+  end
+
+  describe "changeset/1 returns an invalid changeset" do
+    test "when name is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, nil)
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :name)
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "")
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "?")
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["should be at least 2 character(s)"]
+    end
+
+    test "when code is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, nil)
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :code)
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "")
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "A")
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["should be 2 character(s)"]
+    end
+
+    test "when code is invalid", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "??")
+
+      changeset = State.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["must contain only characters A-Z"]
+    end
+  end
+end

--- a/test/api/location_test.exs
+++ b/test/api/location_test.exs
@@ -5,12 +5,14 @@ defmodule Api.LocationTest do
 
   alias Api.Location
   alias Api.Location.Country
+  alias Api.Location.State
   alias Ecto.Changeset
 
   setup do
-    attrs = params_for(:country)
+    country_attrs = params_for(:country)
+    state_attrs = params_for(:state)
 
-    {:ok, attrs: attrs}
+    {:ok, country_attrs: country_attrs, state_attrs: state_attrs}
   end
 
   describe "list_countries/0" do
@@ -46,7 +48,7 @@ defmodule Api.LocationTest do
   end
 
   describe "create_country/1 returns :ok" do
-    test "when the country attributes are valid", %{attrs: attrs} do
+    test "when the country attributes are valid", %{country_attrs: attrs} do
       assert {:ok, %Country{} = country} = Location.create_country(attrs)
 
       assert attrs.name == country.name
@@ -75,7 +77,7 @@ defmodule Api.LocationTest do
       assert errors.code == ["can't be blank"]
     end
 
-    test "when the country code already exists", %{attrs: attrs} do
+    test "when the country code already exists", %{country_attrs: attrs} do
       attrs =
         insert(:country)
         |> then(&Map.put(attrs, :code, &1.code))
@@ -91,7 +93,7 @@ defmodule Api.LocationTest do
   describe "update_country/2 returns :ok" do
     setup [:insert_country]
 
-    test "when the country attributes are valid", %{country: country, attrs: attrs} do
+    test "when the country attributes are valid", %{country: country, country_attrs: attrs} do
       assert {:ok, %Country{} = country} = Location.update_country(country, attrs)
 
       assert attrs.name == country.name
@@ -137,9 +139,127 @@ defmodule Api.LocationTest do
     end
   end
 
+  describe "list_states/0" do
+    test "without states returns an empty list" do
+      assert [] == Location.list_states()
+    end
+
+    test "with states returns all states" do
+      state = insert(:state)
+
+      assert [state] == Location.list_states()
+    end
+  end
+
+  describe "get_state/1 returns :ok" do
+    setup [:insert_state]
+
+    test "when the given id is found", %{state: %{id: id} = state} do
+      assert {:ok, %State{} = ^state} = Location.get_state(id)
+    end
+  end
+
+  describe "get_state/1 returns :error" do
+    test "when the given id is not found" do
+      id = Ecto.UUID.generate()
+
+      assert {:error, changeset} = Location.get_state(id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "create_state/1 returns :ok" do
+    test "when the state attributes are valid", %{state_attrs: attrs} do
+      assert {:ok, %State{} = state} = Location.create_state(attrs)
+
+      assert attrs.name == state.name
+      assert attrs.code == state.code
+    end
+  end
+
+  describe "create_state/1 returns :error" do
+    test "when the state attributes are invalid" do
+      attrs = %{code: "??", name: "?"}
+
+      assert {:error, changeset} = Location.create_state(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["should be at least 2 character(s)"]
+      assert errors.code == ["must contain only characters A-Z"]
+    end
+
+    test "when the state attributes is not provided" do
+      assert {:error, changeset} = Location.create_state()
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["can't be blank"]
+      assert errors.code == ["can't be blank"]
+    end
+  end
+
+  describe "update_state/2 returns :ok" do
+    setup [:insert_state]
+
+    test "when the state attributes are valid", %{state: state, state_attrs: attrs} do
+      assert {:ok, %State{} = state} = Location.update_state(state, attrs)
+
+      assert attrs.name == state.name
+      assert attrs.code == state.code
+    end
+  end
+
+  describe "update_state/2 returns :error" do
+    setup [:insert_state]
+
+    test "when the state attributes are invalid", %{state: state} do
+      invalid_attrs = %{code: nil, name: "a"}
+
+      assert {:error, changeset} = Location.update_state(state, invalid_attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["should be at least 2 character(s)"] == errors.name
+      assert ["can't be blank"] == errors.code
+      assert {:ok, state} == Location.get_state(state.id)
+    end
+  end
+
+  describe "delete_state/1" do
+    setup [:insert_state]
+
+    test "deletes the state", %{state: state} do
+      assert {:ok, %State{}} = Location.delete_state(state)
+
+      assert {:error, changeset} = Location.get_state(state.id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "change_state/1" do
+    setup [:insert_state]
+
+    test "returns a changeset", %{state: state} do
+      assert %Changeset{} = Location.change_state(state)
+    end
+  end
+
   defp insert_country(_) do
     :country
     |> insert()
     |> then(&{:ok, country: &1})
+  end
+
+  defp insert_state(_) do
+    :state
+    |> insert()
+    |> then(&{:ok, state: &1})
   end
 end

--- a/test/api/location_test.exs
+++ b/test/api/location_test.exs
@@ -8,13 +8,6 @@ defmodule Api.LocationTest do
   alias Api.Location.State
   alias Ecto.Changeset
 
-  setup do
-    country_attrs = params_for(:country)
-    state_attrs = params_for(:state)
-
-    {:ok, country_attrs: country_attrs, state_attrs: state_attrs}
-  end
-
   describe "list_countries/0" do
     test "without countries returns an empty list" do
       assert [] == Location.list_countries()
@@ -48,7 +41,9 @@ defmodule Api.LocationTest do
   end
 
   describe "create_country/1 returns :ok" do
-    test "when the country attributes are valid", %{country_attrs: attrs} do
+    test "when the country attributes are valid" do
+      attrs = params_for(:country)
+
       assert {:ok, %Country{} = country} = Location.create_country(attrs)
 
       assert attrs.name == country.name
@@ -77,10 +72,10 @@ defmodule Api.LocationTest do
       assert errors.code == ["can't be blank"]
     end
 
-    test "when the country code already exists", %{country_attrs: attrs} do
+    test "when the country code already exists" do
       attrs =
-        insert(:country)
-        |> then(&Map.put(attrs, :code, &1.code))
+        params_for(:country)
+        |> Map.put(:code, insert(:country).code)
 
       assert {:error, changeset} = Location.create_country(attrs)
       errors = errors_on(changeset)
@@ -93,7 +88,9 @@ defmodule Api.LocationTest do
   describe "update_country/2 returns :ok" do
     setup [:insert_country]
 
-    test "when the country attributes are valid", %{country: country, country_attrs: attrs} do
+    test "when the country attributes are valid", %{country: country} do
+      attrs = params_for(:country)
+
       assert {:ok, %Country{} = country} = Location.update_country(country, attrs)
 
       assert attrs.name == country.name
@@ -172,7 +169,9 @@ defmodule Api.LocationTest do
   end
 
   describe "create_state/1 returns :ok" do
-    test "when the state attributes are valid", %{state_attrs: attrs} do
+    test "when the state attributes are valid" do
+      attrs = params_for(:state)
+
       assert {:ok, %State{} = state} = Location.create_state(attrs)
 
       assert attrs.name == state.name
@@ -205,7 +204,9 @@ defmodule Api.LocationTest do
   describe "update_state/2 returns :ok" do
     setup [:insert_state]
 
-    test "when the state attributes are valid", %{state: state, state_attrs: attrs} do
+    test "when the state attributes are valid", %{state: state} do
+      attrs = params_for(:state)
+
       assert {:ok, %State{} = state} = Location.update_state(state, attrs)
 
       assert attrs.name == state.name
@@ -260,6 +261,18 @@ defmodule Api.LocationTest do
   defp insert_state(_) do
     :state
     |> insert()
+    |> unload(:country)
     |> then(&{:ok, state: &1})
+  end
+
+  def unload(struct, field, cardinality \\ :one) do
+    %{
+      struct
+      | field => %Ecto.Association.NotLoaded{
+          __field__: field,
+          __owner__: struct.__struct__,
+          __cardinality__: cardinality
+        }
+    }
   end
 end

--- a/test/api_web/controllers/city_controller_test.exs
+++ b/test/api_web/controllers/city_controller_test.exs
@@ -1,0 +1,293 @@
+defmodule ApiWeb.CityControllerTest do
+  use ApiWeb.ConnCase
+
+  import Api.Factory
+
+  @id_not_found Ecto.UUID.generate()
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index/2 returns success" do
+    setup [:insert_city, :put_auth]
+
+    test "with a list of cities when there are cities", %{conn: conn, city: city} do
+      conn =
+        get(
+          conn,
+          Routes.country_state_city_path(conn, :index, city.state.country_id, city.state_id)
+        )
+
+      assert %{"success" => true, "data" => [city_data]} = json_response(conn, 200)
+
+      assert city_data["id"] == city.id
+      assert city_data["name"] == city.name
+      assert city_data["state_id"] == city.state_id
+    end
+  end
+
+  describe "create/2 returns success" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city parameters are valid", %{conn: conn, city: city} do
+      city_params = params_for(:city)
+
+      conn =
+        post(
+          conn,
+          Routes.country_state_city_path(conn, :create, city.state.country_id, city.state_id),
+          city: city_params
+        )
+
+      assert %{"success" => true, "data" => city_data} = json_response(conn, 201)
+
+      assert city_data["name"] == city_params.name
+      assert city_data["state_id"] == city.state_id
+    end
+  end
+
+  describe "create/2 returns error" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city parameters are invalid", %{conn: conn, city: city} do
+      city_params = %{name: "?", code: "??"}
+
+      conn =
+        post(
+          conn,
+          Routes.country_state_city_path(conn, :create, city.state.country_id, city.state_id),
+          city: city_params
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+
+    test "when the state id is not found", %{conn: conn, city: city} do
+      city_params = params_for(:city)
+
+      conn =
+        post(
+          conn,
+          Routes.country_state_city_path(conn, :create, city.state.country_id, @id_not_found),
+          city: city_params
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "show/2 returns success" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city id is found", %{conn: conn, city: city} do
+      conn =
+        get(
+          conn,
+          Routes.country_state_city_path(conn, :show, city.state.country_id, city.state_id, city)
+        )
+
+      assert %{"success" => true, "data" => city_data} = json_response(conn, 200)
+
+      assert city_data["id"] == city.id
+      assert city_data["name"] == city.name
+      assert city_data["state_id"] == city.state_id
+    end
+  end
+
+  describe "show/2 returns error" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city id is not found", %{conn: conn, city: city} do
+      conn =
+        get(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :show,
+            city.state.country_id,
+            city.state_id,
+            @id_not_found
+          )
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+
+    test "when the state id is not found", %{conn: conn, city: city} do
+      conn =
+        get(
+          conn,
+          Routes.country_state_city_path(conn, :show, city.state.country_id, @id_not_found, city)
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "update/2 returns success" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city parameters are valid", %{conn: conn, city: city} do
+      city_params = params_for(:city)
+
+      conn =
+        put(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :update,
+            city.state.country_id,
+            city.state_id,
+            city
+          ),
+          city: city_params
+        )
+
+      assert %{"success" => true, "data" => city_data} = json_response(conn, 200)
+
+      assert city_data["id"] == city.id
+      assert city_data["name"] == city_params.name
+      assert city_data["state_id"] == city_params.state_id
+    end
+  end
+
+  describe "update/2 returns error" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city parameters are invalid", %{conn: conn, city: city} do
+      city_params = %{name: "?", code: nil}
+
+      conn =
+        put(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :update,
+            city.state.country_id,
+            city.state_id,
+            city
+          ),
+          city: city_params
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+
+    test "when the state id is not found", %{conn: conn, city: city} do
+      city_params = params_for(:city)
+
+      conn =
+        put(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :update,
+            city.state.country_id,
+            @id_not_found,
+            city
+          ),
+          city: city_params
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns success" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city is found", %{conn: conn, city: city} do
+      conn =
+        delete(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :delete,
+            city.state.country_id,
+            city.state_id,
+            city
+          )
+        )
+
+      assert response(conn, 204)
+
+      conn =
+        get(
+          conn,
+          Routes.country_state_city_path(conn, :show, city.state.country_id, city.state_id, city)
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns error" do
+    setup [:insert_city, :put_auth]
+
+    test "when the city is not found", %{conn: conn, city: city} do
+      conn =
+        delete(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :delete,
+            city.state.country_id,
+            city.state_id,
+            @id_not_found
+          )
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+
+    test "when the state is not found", %{conn: conn, city: city} do
+      conn =
+        delete(
+          conn,
+          Routes.country_state_city_path(
+            conn,
+            :delete,
+            city.state.country_id,
+            @id_not_found,
+            city
+          )
+        )
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  defp insert_city(_) do
+    :city
+    |> insert()
+    |> Api.Repo.preload(:state)
+    |> then(&{:ok, city: &1})
+  end
+
+  defp put_auth(%{conn: conn}) do
+    %{token: %{access: token}} = build(:auth)
+
+    conn
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> then(&{:ok, conn: &1})
+  end
+end

--- a/test/api_web/controllers/state_controller_test.exs
+++ b/test/api_web/controllers/state_controller_test.exs
@@ -1,0 +1,152 @@
+defmodule ApiWeb.StateControllerTest do
+  use ApiWeb.ConnCase
+
+  import Api.Factory
+
+  @id_not_found Ecto.UUID.generate()
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index/2 returns success" do
+    setup [:insert_state, :put_auth]
+
+    test "with a list of states when there are states", %{conn: conn, state: state} do
+      conn = get(conn, Routes.state_path(conn, :index))
+
+      assert %{"success" => true, "data" => [state_data]} = json_response(conn, 200)
+
+      assert state_data["id"] == state.id
+      assert state_data["name"] == state.name
+      assert state_data["code"] == state.code
+    end
+  end
+
+  describe "create/2 returns success" do
+    setup [:put_auth]
+
+    test "when the state parameters are valid", %{conn: conn} do
+      state_params = params_for(:state)
+
+      conn = post(conn, Routes.state_path(conn, :create), state: state_params)
+
+      assert %{"success" => true, "data" => state_data} = json_response(conn, 201)
+
+      assert state_data["name"] == state_params.name
+      assert state_data["code"] == state_params.code
+    end
+  end
+
+  describe "create/2 returns error" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state parameters are invalid", %{conn: conn} do
+      state_params = %{name: "?", code: "??"}
+
+      conn = post(conn, Routes.state_path(conn, :create), state: state_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["code"] == ["must contain only characters A-Z"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+  end
+
+  describe "show/2 returns success" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state id is found", %{conn: conn, state: state} do
+      conn = get(conn, Routes.state_path(conn, :show, state))
+
+      assert %{"success" => true, "data" => state_data} = json_response(conn, 200)
+
+      assert state_data["id"] == state.id
+      assert state_data["name"] == state.name
+      assert state_data["code"] == state.code
+    end
+  end
+
+  describe "show/2 returns error" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state id is not found", %{conn: conn} do
+      conn = get(conn, Routes.state_path(conn, :show, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "update/2 returns success" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state parameters are valid", %{conn: conn, state: state} do
+      state_params = params_for(:state)
+
+      conn = put(conn, Routes.state_path(conn, :update, state), state: state_params)
+
+      assert %{"success" => true, "data" => state_data} = json_response(conn, 200)
+
+      assert state_data["id"] == state.id
+      assert state_data["name"] == state_params.name
+      assert state_data["code"] == state_params.code
+    end
+  end
+
+  describe "update/2 returns error" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state parameters are invalid", %{conn: conn, state: state} do
+      state_params = %{name: "?", code: nil}
+
+      conn = put(conn, Routes.state_path(conn, :update, state), state: state_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["code"] == ["can't be blank"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+  end
+
+  describe "delete/2 returns success" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state is found", %{conn: conn, state: state} do
+      conn = delete(conn, Routes.state_path(conn, :delete, state))
+      assert response(conn, 204)
+
+      conn = get(conn, Routes.state_path(conn, :show, state))
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns error" do
+    setup [:insert_state, :put_auth]
+
+    test "when the state is not found", %{conn: conn} do
+      conn = delete(conn, Routes.state_path(conn, :delete, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  defp insert_state(_) do
+    :state
+    |> insert()
+    |> then(&{:ok, state: &1})
+  end
+
+  defp put_auth(%{conn: conn}) do
+    %{token: %{access: token}} = build(:auth)
+
+    conn
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> then(&{:ok, conn: &1})
+  end
+end

--- a/test/api_web/views/city_view_test.exs
+++ b/test/api_web/views/city_view_test.exs
@@ -1,0 +1,44 @@
+defmodule ApiWeb.CityViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Api.Factory
+
+  alias ApiWeb.CityView
+
+  describe "render/3 returns success" do
+    setup [:build_city]
+
+    test "with a list of cities", %{city: city} do
+      assert %{success: true, data: data} = render(CityView, "index.json", cities: [city])
+
+      assert [city_data] = data
+
+      assert city_data.id == city.id
+      assert city_data.name == city.name
+      assert city_data.state_id == city.state_id
+    end
+
+    test "with a single city", %{city: city} do
+      assert %{success: true, data: city_data} = render(CityView, "show.json", city: city)
+
+      assert city_data.id == city.id
+      assert city_data.name == city.name
+      assert city_data.state_id == city.state_id
+    end
+
+    test "with city data", %{city: city} do
+      assert city_data = render(CityView, "city.json", city: city)
+
+      assert city_data.id == city.id
+      assert city_data.name == city.name
+      assert city_data.state_id == city.state_id
+    end
+  end
+
+  defp build_city(_) do
+    :city
+    |> build()
+    |> then(&{:ok, city: &1})
+  end
+end

--- a/test/api_web/views/state_view_test.exs
+++ b/test/api_web/views/state_view_test.exs
@@ -17,6 +17,7 @@ defmodule ApiWeb.StateViewTest do
       assert state_data.id == state.id
       assert state_data.code == state.code
       assert state_data.name == state.name
+      assert state_data.country_id == state.country_id
     end
 
     test "with a single state", %{state: state} do
@@ -25,6 +26,7 @@ defmodule ApiWeb.StateViewTest do
       assert state_data.id == state.id
       assert state_data.code == state.code
       assert state_data.name == state.name
+      assert state_data.country_id == state.country_id
     end
 
     test "with state data", %{state: state} do
@@ -33,6 +35,7 @@ defmodule ApiWeb.StateViewTest do
       assert state_data.id == state.id
       assert state_data.code == state.code
       assert state_data.name == state.name
+      assert state_data.country_id == state.country_id
     end
   end
 

--- a/test/api_web/views/state_view_test.exs
+++ b/test/api_web/views/state_view_test.exs
@@ -1,0 +1,44 @@
+defmodule ApiWeb.StateViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Api.Factory
+
+  alias ApiWeb.StateView
+
+  describe "render/3 returns success" do
+    setup [:build_state]
+
+    test "with a list of states", %{state: state} do
+      assert %{success: true, data: data} = render(StateView, "index.json", states: [state])
+
+      assert [state_data] = data
+
+      assert state_data.id == state.id
+      assert state_data.code == state.code
+      assert state_data.name == state.name
+    end
+
+    test "with a single state", %{state: state} do
+      assert %{success: true, data: state_data} = render(StateView, "show.json", state: state)
+
+      assert state_data.id == state.id
+      assert state_data.code == state.code
+      assert state_data.name == state.name
+    end
+
+    test "with state data", %{state: state} do
+      assert state_data = render(StateView, "state.json", state: state)
+
+      assert state_data.id == state.id
+      assert state_data.code == state.code
+      assert state_data.name == state.name
+    end
+  end
+
+  defp build_state(_) do
+    :state
+    |> build()
+    |> then(&{:ok, state: &1})
+  end
+end

--- a/test/support/factories/city_factory.ex
+++ b/test/support/factories/city_factory.ex
@@ -1,0 +1,21 @@
+defmodule Api.Factories.CityFactory do
+  @moduledoc """
+  Generates city data for testing
+  """
+  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
+  alias Api.Location.City
+
+  defmacro __using__(_opts) do
+    quote do
+      def city_factory do
+        %City{
+          id: Faker.UUID.v4(),
+          name: Faker.Address.PtBr.city(),
+          state_id: insert(:state).id,
+          inserted_at: Faker.DateTime.backward(366),
+          updated_at: DateTime.utc_now()
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/state_factory.ex
+++ b/test/support/factories/state_factory.ex
@@ -1,0 +1,21 @@
+defmodule Api.Factories.StateFactory do
+  @moduledoc """
+  Generates state data for testing
+  """
+  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
+  alias Api.Location.State
+
+  defmacro __using__(_opts) do
+    quote do
+      def state_factory do
+        %State{
+          id: Faker.UUID.v4(),
+          name: Faker.Address.PtBr.state(),
+          code: Faker.Address.state_abbr(),
+          inserted_at: Faker.DateTime.backward(366),
+          updated_at: DateTime.utc_now()
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/state_factory.ex
+++ b/test/support/factories/state_factory.ex
@@ -12,6 +12,7 @@ defmodule Api.Factories.StateFactory do
           id: Faker.UUID.v4(),
           name: Faker.Address.PtBr.state(),
           code: Faker.Address.state_abbr(),
+          country_id: insert(:country).id,
           inserted_at: Faker.DateTime.backward(366),
           updated_at: DateTime.utc_now()
         }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -8,4 +8,5 @@ defmodule Api.Factory do
   use Api.Factories.AuthFactory
   use Api.Factories.PersonFactory
   use Api.Factories.CountryFactory
+  use Api.Factories.StateFactory
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -9,4 +9,5 @@ defmodule Api.Factory do
   use Api.Factories.PersonFactory
   use Api.Factories.CountryFactory
   use Api.Factories.StateFactory
+  use Api.Factories.CityFactory
 end


### PR DESCRIPTION
# description

add routes to handle states and cities

## acceptance criteria
* must follow the `restful api` pattern
* should use prefix `/api/countries/:id/states/:id/cities` to the endpoints

## linked issues
- closes #35 
- closes #36 
- closes #37 
- closes #38 
- closes #39 
- closes #40 
- closes #41 
- closes #42 