### PR TITLE
feat: add accounts resource

### DIFF
--- a/lib/api/accounting.ex
+++ b/lib/api/accounting.ex
@@ -1,0 +1,84 @@
+defmodule Api.Accounting do
+  @moduledoc """
+  The Accounting context
+  """
+  alias Api.Accounting.Account
+
+  @doc """
+  Returns a list of accounts
+
+  ## Examples
+
+      iex> list_accounts()
+      [%Account{}, ...]
+
+  """
+  defdelegate list_accounts, to: Account.List, as: :call
+
+  @doc """
+  Gets a account
+
+  ## Examples
+
+      iex> get_account(value)
+      {:ok, %Account{}}
+
+      iex> get_account(bad_value)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate get_account(id), to: Account.Get, as: :call
+
+  @doc """
+  Creates a account
+
+  ## Examples
+
+      iex> create_account(%{field: value})
+      {:ok, %Account{}}
+
+      iex> create_account(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate create_account(attrs \\ %{}), to: Account.Create, as: :call
+
+  @doc """
+  Updates a account
+
+  ## Examples
+
+      iex> update_account(account, %{field: new_value})
+      {:ok, %Account{}}
+
+      iex> update_account(account, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate update_account(account, attrs), to: Account.Update, as: :call
+
+  @doc """
+  Deletes a account
+
+  ## Examples
+
+      iex> delete_account(account)
+      {:ok, %Account{}}
+
+      iex> delete_account(account)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  defdelegate delete_account(account), to: Account.Delete, as: :call
+
+  @doc """
+  Returns a changeset for tracking account changes
+
+  ## Examples
+
+      iex> change_account(account)
+      %Ecto.Changeset{data: %Account{}}
+
+  """
+  defdelegate change_account(account, attrs \\ %{}), to: Account.Change, as: :call
+end

--- a/lib/api/accounting/account.ex
+++ b/lib/api/accounting/account.ex
@@ -1,0 +1,27 @@
+defmodule Api.Accounting.Account do
+  use Api.Schema
+
+  import Ecto.Changeset
+
+  schema "accounts" do
+    field :level, :integer
+    field :code, :string
+    field :name, :string
+    field :type, Ecto.Enum, values: [debit: 0, credit: 1]
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(account, attrs) do
+    account
+    |> cast(attrs, [:code, :name, :type, :level])
+    |> validate_required([:code, :name, :type, :level])
+    |> unique_constraint(:id, name: :accounts_pkey)
+    |> unique_constraint(:code)
+    |> validate_length(:name, min: 2, max: 150)
+    |> validate_length(:code, min: 1, max: 5)
+    |> validate_format(:code, ~r/^[0-9]+$/, message: "must contain only numbers")
+    |> validate_number(:level, greater_than: 0, less_than: 5)
+  end
+end

--- a/lib/api/accounting/account/change.ex
+++ b/lib/api/accounting/account/change.ex
@@ -1,0 +1,7 @@
+defmodule Api.Accounting.Account.Change do
+  @moduledoc false
+  alias Api.Accounting.Account
+
+  @doc false
+  def call(%Account{} = account, attrs \\ %{}), do: Account.changeset(account, attrs)
+end

--- a/lib/api/accounting/account/create.ex
+++ b/lib/api/accounting/account/create.ex
@@ -1,0 +1,12 @@
+defmodule Api.Accounting.Account.Create do
+  @moduledoc false
+  alias Api.Accounting.Account
+  alias Api.Repo
+
+  @doc false
+  def call(attrs \\ %{}) do
+    %Account{}
+    |> Account.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/api/accounting/account/delete.ex
+++ b/lib/api/accounting/account/delete.ex
@@ -1,0 +1,8 @@
+defmodule Api.Accounting.Account.Delete do
+  @moduledoc false
+  alias Api.Accounting.Account
+  alias Api.Repo
+
+  @doc false
+  def call(%Account{} = account), do: Repo.delete(account)
+end

--- a/lib/api/accounting/account/get.ex
+++ b/lib/api/accounting/account/get.ex
@@ -1,0 +1,17 @@
+defmodule Api.Accounting.Account.Get do
+  @moduledoc false
+  alias Api.Accounting.Account
+  alias Api.Repo
+
+  @doc false
+  def call(id) do
+    Account
+    |> Repo.get!(id)
+    |> then(&{:ok, &1})
+  rescue
+    _ ->
+      :id
+      |> Account.invalid_changeset(id, "not found")
+      |> then(&{:error, &1})
+  end
+end

--- a/lib/api/accounting/account/list.ex
+++ b/lib/api/accounting/account/list.ex
@@ -1,0 +1,8 @@
+defmodule Api.Accounting.Account.List do
+  @moduledoc false
+  alias Api.Accounting.Account
+  alias Api.Repo
+
+  @doc false
+  def call, do: Repo.all(Account)
+end

--- a/lib/api/accounting/account/update.ex
+++ b/lib/api/accounting/account/update.ex
@@ -1,0 +1,12 @@
+defmodule Api.Accounting.Account.Update do
+  @moduledoc false
+  alias Api.Accounting.Account
+  alias Api.Repo
+
+  @doc false
+  def call(%Account{} = account, attrs) do
+    account
+    |> Account.changeset(attrs)
+    |> Repo.update()
+  end
+end

--- a/lib/api_web/controllers/account_controller.ex
+++ b/lib/api_web/controllers/account_controller.ex
@@ -1,0 +1,61 @@
+defmodule ApiWeb.AccountController do
+  @moduledoc """
+  Controller responsible for handling accounts
+  """
+  use ApiWeb, :controller
+
+  alias Api.Accounting
+  alias Api.Accounting.Account
+
+  action_fallback ApiWeb.FallbackController
+
+  @doc """
+  Handles requests to list accounts
+  """
+  def index(conn, _params) do
+    accounts = Accounting.list_accounts()
+
+    render(conn, "index.json", accounts: accounts)
+  end
+
+  @doc """
+  Handles requests to create account
+  """
+  def create(conn, %{"account" => account_params}) do
+    with {:ok, %Account{} = account} <- Accounting.create_account(account_params) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", Routes.account_path(conn, :show, account))
+      |> render("show.json", account: account)
+    end
+  end
+
+  @doc """
+  Handles requests to show account
+  """
+  def show(conn, %{"id" => id}) do
+    with {:ok, account} <- Accounting.get_account(id) do
+      render(conn, "show.json", account: account)
+    end
+  end
+
+  @doc """
+  Handles requests to update account
+  """
+  def update(conn, %{"id" => id, "account" => account_params}) do
+    with {:ok, account} <- Accounting.get_account(id),
+         {:ok, %Account{} = account} <- Accounting.update_account(account, account_params) do
+      render(conn, "show.json", account: account)
+    end
+  end
+
+  @doc """
+  Handles requests to delete account
+  """
+  def delete(conn, %{"id" => id}) do
+    with {:ok, account} <- Accounting.get_account(id),
+         {:ok, %Account{}} <- Accounting.delete_account(account) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/api_web/router.ex
+++ b/lib/api_web/router.ex
@@ -21,6 +21,7 @@ defmodule ApiWeb.Router do
 
     resources "/users", UserController, except: [:new, :edit]
     resources "/persons", PersonController, except: [:new, :edit]
+    resources "/accounts", AccountController, except: [:new, :edit]
 
     resources "/countries", CountryController, except: [:new, :edit] do
       resources "/states", StateController, except: [:new, :edit] do

--- a/lib/api_web/views/account_view.ex
+++ b/lib/api_web/views/account_view.ex
@@ -1,0 +1,36 @@
+defmodule ApiWeb.AccountView do
+  @moduledoc """
+  View responsible for rendering accounts
+  """
+  use ApiWeb, :view
+
+  alias Api.Accounting.Account
+  alias ApiWeb.AccountView
+
+  @doc """
+  Renders a list of accounts
+  """
+  def render("index.json", %{accounts: accounts}) do
+    %{success: true, data: render_many(accounts, AccountView, "account.json")}
+  end
+
+  @doc """
+  Renders a single account
+  """
+  def render("show.json", %{account: account}) do
+    %{success: true, data: render_one(account, AccountView, "account.json")}
+  end
+
+  @doc """
+  Renders a account data
+  """
+  def render("account.json", %{account: account}) do
+    %{
+      id: account.id,
+      code: account.code,
+      name: account.name,
+      type: Ecto.Enum.mappings(Account, :type)[account.type],
+      level: account.level
+    }
+  end
+end

--- a/priv/repo/migrations/20230321235552_create_accounts.exs
+++ b/priv/repo/migrations/20230321235552_create_accounts.exs
@@ -1,0 +1,16 @@
+defmodule Api.Repo.Migrations.CreateAccounts do
+  use Ecto.Migration
+
+  def change do
+    create table(:accounts) do
+      add :code, :string, null: false
+      add :name, :string, null: false
+      add :type, :integer, null: false
+      add :level, :integer, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:accounts, [:code])
+  end
+end

--- a/test/api/accounting/account_test.exs
+++ b/test/api/accounting/account_test.exs
@@ -1,0 +1,210 @@
+defmodule Api.Accounting.AccountTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Accounting.Account
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:account)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "changeset/1 returns a valid changeset" do
+    test "when level is valid", %{attrs: attrs} do
+      changeset = Account.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.level == attrs.level
+    end
+
+    test "when name is valid", %{attrs: attrs} do
+      changeset = Account.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.name == attrs.name
+    end
+
+    test "when code is valid", %{attrs: attrs} do
+      changeset = Account.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.code == attrs.code
+    end
+
+    test "when type is valid", %{attrs: attrs} do
+      changeset = Account.changeset(attrs)
+
+      assert %Changeset{valid?: true} = changeset
+      assert changeset.changes.type == Enum.at(Ecto.Enum.values(Account, :type), attrs.type)
+    end
+  end
+
+  describe "changeset/1 returns an invalid changeset" do
+    test "when name is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, nil)
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :name)
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["can't be blank"]
+    end
+
+    test "when name is too short", %{attrs: attrs} do
+      attrs = Map.put(attrs, :name, "?")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.name == ["should be at least 2 character(s)"]
+    end
+
+    test "when code is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, nil)
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :code)
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["can't be blank"]
+    end
+
+    test "when code has invalid format", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "???")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.code == ["must contain only numbers"]
+    end
+
+    test "when code is too long", %{attrs: attrs} do
+      attrs = Map.put(attrs, :code, "0123456789")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.code == ["should be at most 5 character(s)"]
+    end
+
+    test "when level is null", %{attrs: attrs} do
+      attrs = Map.put(attrs, :level, nil)
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.level == ["can't be blank"]
+    end
+
+    test "when level is not provided", %{attrs: attrs} do
+      attrs = Map.delete(attrs, :level)
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.level == ["can't be blank"]
+    end
+
+    test "when level is empty", %{attrs: attrs} do
+      attrs = Map.put(attrs, :level, "")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.level == ["can't be blank"]
+    end
+
+    test "when level is too long", %{attrs: attrs} do
+      attrs = Map.put(attrs, :level, "0123456789")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+      assert errors.level == ["must be less than 5"]
+    end
+
+    test "when level has invalid format", %{attrs: attrs} do
+      attrs = Map.put(attrs, :level, "invalid_format")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.level == ["is invalid"]
+    end
+
+    test "when type has invalid value", %{attrs: attrs} do
+      attrs = Map.put(attrs, :type, "666")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.type == ["is invalid"]
+    end
+
+    test "when type is invalid", %{attrs: attrs} do
+      attrs = Map.put(attrs, :type, "invalid")
+
+      changeset = Account.changeset(attrs)
+      errors = errors_on(changeset)
+
+      assert %Changeset{valid?: false} = changeset
+
+      assert errors.type == ["is invalid"]
+    end
+  end
+end

--- a/test/api/accounting_test.exs
+++ b/test/api/accounting_test.exs
@@ -1,0 +1,150 @@
+defmodule Api.AccountingTest do
+  use Api.DataCase, async: true
+
+  import Api.Factory
+
+  alias Api.Accounting
+  alias Api.Accounting.Account
+  alias Ecto.Changeset
+
+  setup do
+    attrs = params_for(:account)
+
+    {:ok, attrs: attrs}
+  end
+
+  describe "list_accounts/0" do
+    test "without accounts returns an empty list" do
+      assert [] == Accounting.list_accounts()
+    end
+
+    test "with accounts returns all accounts" do
+      account = insert(:account)
+
+      assert [account] == Accounting.list_accounts()
+    end
+  end
+
+  describe "get_account/1 returns :ok" do
+    setup [:insert_account]
+
+    test "when the given id is found", %{account: %{id: id} = account} do
+      assert {:ok, %Account{} = ^account} = Accounting.get_account(id)
+    end
+  end
+
+  describe "get_account/1 returns :error" do
+    test "when the given id is not found" do
+      id = Ecto.UUID.generate()
+
+      assert {:error, changeset} = Accounting.get_account(id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "create_account/1 returns :ok" do
+    test "when the account attributes are valid", %{attrs: attrs} do
+      assert {:ok, %Account{} = account} = Accounting.create_account(attrs)
+
+      assert attrs.name == account.name
+      assert attrs.code == account.code
+      assert attrs.level == account.level
+      assert Enum.at(Ecto.Enum.values(Account, :type), attrs.type) == account.type
+    end
+  end
+
+  describe "create_account/1 returns :error" do
+    test "when the account attributes are invalid" do
+      attrs = %{code: "?", name: nil, level: "666", type: 666}
+
+      assert {:error, changeset} = Accounting.create_account(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["can't be blank"]
+      assert errors.level == ["must be less than 5"]
+      assert errors.type == ["is invalid"]
+    end
+
+    test "when the account attributes is not provided" do
+      assert {:error, changeset} = Accounting.create_account()
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.name == ["can't be blank"]
+      assert errors.type == ["can't be blank"]
+    end
+
+    test "when the account code already exists", %{attrs: attrs} do
+      attrs =
+        insert(:account)
+        |> then(&Map.put(attrs, :code, &1.code))
+
+      assert {:error, changeset} = Accounting.create_account(attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["has already been taken"] == errors.code
+    end
+  end
+
+  describe "update_account/2 returns :ok" do
+    setup [:insert_account]
+
+    test "when the account attributes are valid", %{account: account, attrs: attrs} do
+      assert {:ok, %Account{} = account} = Accounting.update_account(account, attrs)
+
+      assert attrs.name == account.name
+      assert attrs.code == account.code
+      assert attrs.level == account.level
+      assert Enum.at(Ecto.Enum.values(Account, :type), attrs.type) == account.type
+    end
+  end
+
+  describe "update_account/2 returns :error" do
+    setup [:insert_account]
+
+    test "when the account attributes are invalid", %{account: account} do
+      invalid_attrs = %{code: "@", level: "?", name: "a", type: nil}
+
+      assert {:error, changeset} = Accounting.update_account(account, invalid_attrs)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert ["should be at least 2 character(s)"] == errors.name
+      assert ["can't be blank"] == errors.type
+      assert {:ok, account} == Accounting.get_account(account.id)
+    end
+  end
+
+  describe "delete_account/1" do
+    setup [:insert_account]
+
+    test "deletes the account", %{account: account} do
+      assert {:ok, %Account{}} = Accounting.delete_account(account)
+
+      assert {:error, changeset} = Accounting.get_account(account.id)
+      errors = errors_on(changeset)
+
+      refute changeset.valid?
+      assert errors.id == ["not found"]
+    end
+  end
+
+  describe "change_account/1" do
+    setup [:insert_account]
+
+    test "returns a changeset", %{account: account} do
+      assert %Changeset{} = Accounting.change_account(account)
+    end
+  end
+
+  defp insert_account(_) do
+    :account
+    |> insert()
+    |> then(&{:ok, account: &1})
+  end
+end

--- a/test/api_web/controllers/account_controller_test.exs
+++ b/test/api_web/controllers/account_controller_test.exs
@@ -1,0 +1,163 @@
+defmodule ApiWeb.AccountControllerTest do
+  use ApiWeb.ConnCase
+
+  import Api.Factory
+
+  alias Api.Accounting.Account
+
+  @id_not_found Ecto.UUID.generate()
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index/2 returns success" do
+    setup [:insert_account, :put_auth]
+
+    test "with a list of accounts when there are accounts", %{conn: conn, account: account} do
+      conn = get(conn, Routes.account_path(conn, :index))
+
+      assert %{"success" => true, "data" => [account_data]} = json_response(conn, 200)
+
+      assert account_data["id"] == account.id
+      assert account_data["code"] == account.code
+      assert account_data["name"] == account.name
+      assert account_data["level"] == account.level
+      assert account_data["type"] == Ecto.Enum.mappings(Account, :type)[account.type]
+    end
+  end
+
+  describe "create/2 returns success" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account parameters are valid", %{conn: conn} do
+      account_params = params_for(:account)
+
+      conn = post(conn, Routes.account_path(conn, :create), account: account_params)
+
+      assert %{"success" => true, "data" => account_data} = json_response(conn, 201)
+
+      assert account_data["name"] == account_params.name
+      assert account_data["code"] == account_params.code
+      assert account_data["level"] == account_params.level
+      assert account_data["type"] == account_params.type
+    end
+  end
+
+  describe "create/2 returns error" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account parameters are invalid", %{conn: conn} do
+      account_params = %{code: "?", name: "?", level: "?", type: nil}
+
+      conn = post(conn, Routes.account_path(conn, :create), account: account_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["type"] == ["can't be blank"]
+      assert errors["name"] == ["should be at least 2 character(s)"]
+    end
+  end
+
+  describe "show/2 returns success" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account id is found", %{conn: conn, account: account} do
+      conn = get(conn, Routes.account_path(conn, :show, account))
+
+      assert %{"success" => true, "data" => account_data} = json_response(conn, 200)
+
+      assert account_data["id"] == account.id
+      assert account_data["code"] == account.code
+      assert account_data["name"] == account.name
+      assert account_data["level"] == account.level
+      assert account_data["type"] == Ecto.Enum.mappings(Account, :type)[account.type]
+    end
+  end
+
+  describe "show/2 returns error" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account id is not found", %{conn: conn} do
+      conn = get(conn, Routes.account_path(conn, :show, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "update/2 returns success" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account parameters are valid", %{conn: conn, account: account} do
+      account_params = params_for(:account)
+
+      conn = put(conn, Routes.account_path(conn, :update, account), account: account_params)
+
+      assert %{"success" => true, "data" => account_data} = json_response(conn, 200)
+
+      assert account_data["id"] == account.id
+      assert account_data["code"] == account_params.code
+      assert account_data["name"] == account_params.name
+      assert account_data["level"] == account_params.level
+      assert account_data["type"] == account_params.type
+    end
+  end
+
+  describe "update/2 returns error" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account parameters are invalid", %{conn: conn, account: account} do
+      account_params = %{code: "@", name: nil, level: "666", type: 666}
+
+      conn = put(conn, Routes.account_path(conn, :update, account), account: account_params)
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["name"] == ["can't be blank"]
+      assert errors["level"] == ["must be less than 5"]
+      assert errors["type"] == ["is invalid"]
+    end
+  end
+
+  describe "delete/2 returns success" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account is found", %{conn: conn, account: account} do
+      conn = delete(conn, Routes.account_path(conn, :delete, account))
+      assert response(conn, 204)
+
+      conn = get(conn, Routes.account_path(conn, :show, account))
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  describe "delete/2 returns error" do
+    setup [:insert_account, :put_auth]
+
+    test "when the account is not found", %{conn: conn} do
+      conn = delete(conn, Routes.account_path(conn, :delete, @id_not_found))
+
+      assert %{"success" => false, "errors" => errors} = json_response(conn, 422)
+
+      assert errors["id"] == ["not found"]
+    end
+  end
+
+  defp insert_account(_) do
+    :account
+    |> insert()
+    |> then(&{:ok, account: &1})
+  end
+
+  defp put_auth(%{conn: conn}) do
+    %{token: %{access: token}} = build(:auth)
+
+    conn
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> then(&{:ok, conn: &1})
+  end
+end

--- a/test/api_web/views/account_view_test.exs
+++ b/test/api_web/views/account_view_test.exs
@@ -1,0 +1,52 @@
+defmodule ApiWeb.AccountViewTest do
+  use ApiWeb.ConnCase, async: true
+
+  import Phoenix.View
+  import Api.Factory
+
+  alias Api.Accounting.Account
+  alias ApiWeb.AccountView
+
+  describe "render/3 returns success" do
+    setup [:build_account]
+
+    test "with a list of accounts", %{account: account} do
+      assert %{success: true, data: data} = render(AccountView, "index.json", accounts: [account])
+      assert [account_data] = data
+
+      assert account_data.id == account.id
+      assert account_data.type == Ecto.Enum.mappings(Account, :type)[account.type]
+      assert account_data.code == account.code
+      assert account_data.level == account.level
+      assert account_data.name == account.name
+    end
+
+    test "with a single account", %{account: account} do
+      assert %{success: true, data: account_data} =
+               render(AccountView, "show.json", account: account)
+
+      assert account_data.id == account.id
+      assert account_data.type == Ecto.Enum.mappings(Account, :type)[account.type]
+      assert account_data.code == account.code
+      assert account_data.level == account.level
+      assert account_data.name == account.name
+    end
+
+    test "with account data", %{account: account} do
+      assert account_data = render(AccountView, "account.json", account: account)
+
+      assert account_data.id == account.id
+      assert account_data.type == Ecto.Enum.mappings(Account, :type)[account.type]
+      assert account_data.code == account.code
+      assert account_data.level == account.level
+      assert account_data.name == account.name
+    end
+  end
+
+  defp build_account(_) do
+    :account
+    |> build()
+    |> then(&Map.put(&1, :type, Enum.at(Ecto.Enum.values(Account, :type), &1.type)))
+    |> then(&{:ok, account: &1})
+  end
+end

--- a/test/support/factories/account_factory.ex
+++ b/test/support/factories/account_factory.ex
@@ -1,0 +1,23 @@
+defmodule Api.Factories.AccountFactory do
+  @moduledoc """
+  Generates account data for testing
+  """
+  # credo:disable-for-this-file Credo.Check.Design.AliasUsage
+  alias Api.Accounting.Account
+
+  defmacro __using__(_opts) do
+    quote do
+      def account_factory do
+        %Account{
+          id: Faker.UUID.v4(),
+          name: Faker.Cat.name(),
+          code: "#{Faker.Random.Elixir.random_between(1, 59999)}",
+          level: Faker.Random.Elixir.random_between(1, 4),
+          type: Faker.Random.Elixir.random_between(0, 1),
+          inserted_at: Faker.DateTime.backward(366),
+          updated_at: DateTime.utc_now()
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -10,4 +10,5 @@ defmodule Api.Factory do
   use Api.Factories.CountryFactory
   use Api.Factories.StateFactory
   use Api.Factories.CityFactory
+  use Api.Factories.AccountFactory
 end


### PR DESCRIPTION
# description

add routes to handle accounts

## acceptance criteria
* must follow the `restful api` pattern
* should use prefix `/api/accounts` to the endpoints

## linked issues
- closes #51 
- closes #52 
- closes #53 
- closes #54 